### PR TITLE
Support enum flags of varying case

### DIFF
--- a/src/base-commands/twilio-api-command.js
+++ b/src/base-commands/twilio-api-command.js
@@ -167,14 +167,16 @@ TwilioApiCommand.setUpNewCommandClass = NewCommandClass => {
       }
     };
 
-    let flagType;
+    const flagType = typeMap[param.schema.type];
+
     if (doesObjectHaveProperty(param.schema, 'enum')) {
-      flagType = flags.enum;
-      flagConfig.options = param.schema.enum
+      // We want the best of all worlds. We want the help to show just lower-case options, but accept all options. Since
+      // oclif doesn't support this, we'll create a string that matches the enum flag text and let the schema validator
+      // take care of the actual validation.
+      const options = param.schema.enum
         .map(value => value.toLowerCase()) // standardize the enum values
         .filter((value, index, self) => self.indexOf(value) === index); // remove duplicates
-    } else {
-      flagType = typeMap[param.schema.type];
+      flagConfig.helpValue = `(${options.join('|')})`; // format it like the help plugin
     }
 
     if (flagType) {

--- a/test/base-commands/twilio-api-command.test.js
+++ b/test/base-commands/twilio-api-command.test.js
@@ -48,8 +48,8 @@ describe('base-commands', () => {
         );
         expect(NewCommandClass.flags.from.required).to.be.true;
         expect(NewCommandClass.flags.method.required).to.be.false;
-        expect(NewCommandClass.flags.method.optionType).to.equal('enum');
-        expect(NewCommandClass.flags.method.options).to.eql(['head', 'get', 'post', 'patch', 'put', 'delete']);
+        expect(NewCommandClass.flags.method.type).to.equal('option');
+        expect(NewCommandClass.flags.method.helpValue).to.eql('(head|get|post|patch|put|delete)');
         expect(NewCommandClass.flags.record.type).to.equal('boolean');
 
         expect(Object.keys(NewCommandClass.flags).length).to.equal(


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.


Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
# Fixes # 

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added in line documentation to the code I modified

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

### Short description of what this PR does:
- Accept varying case command API options and display the lower-case options in the help
- This is to support APIs that only accept a specific case, but don't call that out in their definition

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a Github Issue in this repository.


