### PR TITLE
Spit out a warning when plugins have conflicting commands or aliases

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
       }
     },
     "hooks": {
-      "init": "./src/hooks/init/twilio-api"
+      "init": "./src/hooks/init/twilio-api",
+      "post-api-plugin": "./src/hooks/post-api-plugin/plugin-verification"
     }
   },
   "repository": {

--- a/src/hooks/init/twilio-api.js
+++ b/src/hooks/init/twilio-api.js
@@ -65,6 +65,17 @@ class TwilioRestApiPlugin extends Plugin {
     this.domainTopics = [{ name: BASE_TOPIC_NAME, description: 'advanced access to all of the Twilio APIs' }];
     this.versionTopics = [];
     Object.keys(this.apiBrowser.domains).forEach(this.scanDomain, this);
+
+    this.commands = this.actions.map(actionDefinition => {
+      // Because oclif is constructing the object for us,
+      // we can't pass the actionDefinition in through
+      // the constructor, so we make it a static property
+      // of the newly created command class.
+      const NewCommandClass = class extends TwilioApiCommand {};
+      NewCommandClass.actionDefinition = actionDefinition;
+      TwilioApiCommand.setUpNewCommandClass(NewCommandClass);
+      return NewCommandClass;
+    });
   }
 
   get hooks() {
@@ -86,19 +97,6 @@ class TwilioRestApiPlugin extends Plugin {
   get commandIDs() {
     return this.actions.map(a => [a.topicName, a.commandName].join(TOPIC_SEPARATOR));
   }
-
-  get commands() {
-    return this.actions.map(actionDefinition => {
-      // Because oclif is constructing the object for us,
-      // we can't pass the actionDefinition in through
-      // the constructor, so we make it a static property
-      // of the newly created command class.
-      const NewCommandClass = class extends TwilioApiCommand {};
-      NewCommandClass.actionDefinition = actionDefinition;
-      TwilioApiCommand.setUpNewCommandClass(NewCommandClass);
-      return NewCommandClass;
-    });
-  }
 }
 
 module.exports = async function () {
@@ -108,4 +106,5 @@ module.exports = async function () {
   twilioApiPlugin.tag = 'latest';
   twilioApiPlugin.type = 'core';
   this.config.plugins.push(twilioApiPlugin);
+  await this.config.runHook('post-api-plugin', twilioApiPlugin);
 };

--- a/src/hooks/post-api-plugin/plugin-verification.js
+++ b/src/hooks/post-api-plugin/plugin-verification.js
@@ -1,0 +1,49 @@
+const { logger } = require('@twilio/cli-core').services.logging;
+const { splitArray } = require('@twilio/cli-core').services.JSUtils;
+
+const MessageTemplates = require('../../services/messaging/templates');
+
+const checkCommandConflicts = (corePlugins, installedPlugins) => {
+  const commandSet = new Set();
+
+  const collisionCheck = (plugin, command) => {
+    // If there's a collision or conflict, issue a stern warning.
+    if (commandSet.has(command)) {
+      logger.warn(MessageTemplates.commandConflict({ plugin: plugin.name, command: command }));
+    }
+    commandSet.add(command);
+  };
+
+  // Add every command and alias from the our core plugins to the unique collection.
+  corePlugins.forEach(plugin => {
+    plugin.commands.forEach(command => {
+      commandSet.add(command.id);
+
+      if (command.aliases)
+        command.aliases.forEach(alias => commandSet.add(alias));
+    });
+  });
+
+  // Check all commands and aliases from installed plugins for collisions/conflicts with our core plugins, other
+  // installed plugins, and the plugin itself.
+  installedPlugins.forEach(plugin => {
+    plugin.commands.forEach(command => {
+      collisionCheck(plugin, command.id);
+
+      if (command.aliases)
+        command.aliases.forEach(alias => collisionCheck(plugin, alias));
+    });
+  });
+};
+
+module.exports = function (twilioApiPlugin) {
+  const corePluginNames = [this.config.name, twilioApiPlugin.name];
+  const isCorePlugin = plugin => {
+    return corePluginNames.includes(plugin.name);
+  };
+
+  // Split the plugins into "core" and "installed".
+  const [corePlugins, installedPlugins] = splitArray(this.config.plugins, isCorePlugin);
+
+  checkCommandConflicts(corePlugins, installedPlugins);
+};

--- a/src/services/messaging/templates.js
+++ b/src/services/messaging/templates.js
@@ -1,0 +1,3 @@
+const { templatize } = require('@twilio/cli-core').services.templating;
+
+exports.commandConflict = templatize`The plugin "${'plugin'}" contains a conflicting command: ${'command'}`;

--- a/src/services/messaging/templates.js
+++ b/src/services/messaging/templates.js
@@ -1,3 +1,6 @@
 const { templatize } = require('@twilio/cli-core').services.templating;
 
-exports.commandConflict = templatize`The plugin "${'plugin'}" contains a conflicting command: ${'command'}`;
+exports.commandConflict = templatize`The plugin "${'plugin'}" contains a conflicting command name: ${'command'}. \
+You may discover commands are unexpectedly grouped together or conflict. \
+You may wish to uninstall this plugin via 'twilio plugins:uninstall'. \
+Contact the plugin developer to update the plugin.`;

--- a/test/hooks/init/twilio-api.test.js
+++ b/test/hooks/init/twilio-api.test.js
@@ -1,7 +1,7 @@
 const pluginFunc = require('../../../src/hooks/init/twilio-api');
 const { expect, test } = require('@twilio/cli-test');
 
-const getFakeContext = () => ({ config: { plugins: [] } });
+const getFakeContext = () => ({ config: { plugins: [], runHook: () => '' } });
 
 describe('hooks', () => {
   describe('init', () => {

--- a/test/hooks/post-api-plugin/plugin-verification.js.test.js
+++ b/test/hooks/post-api-plugin/plugin-verification.js.test.js
@@ -1,0 +1,81 @@
+const pluginFunc = require('../../../src/hooks/post-api-plugin/plugin-verification');
+const { expect, test } = require('@twilio/cli-test');
+
+const CLI_NAME = 'twilio-cli';
+
+const getCliPlugin = () => ({
+  name: CLI_NAME,
+  commands: [{
+    id: 'login',
+    aliases: ['logon']
+  }, {
+    id: 'feedback'
+  }, {
+    id: 'api'
+  }]
+});
+
+const getApiPlugin = () => ({
+  name: 'api-plugin',
+  commands: [{
+    id: 'api'
+  }]
+});
+
+const getConformingPlugin = () => ({
+  name: 'plugin-meals',
+  commands: [{
+    id: 'breakfast'
+  }, {
+    id: 'lunch',
+    aliases: ['dinner']
+  }]
+});
+
+const getConflictingPlugin = () => ({
+  name: 'plugin-schmlugin',
+  commands: [{
+    id: 'logon'
+  }, {
+    id: 'feed:me',
+    aliases: ['feedback']
+  }]
+});
+
+const getFakeConfig = () => ({
+  name: CLI_NAME,
+  plugins: [getCliPlugin(), getApiPlugin()]
+});
+
+describe('hooks', () => {
+  describe('post-api-plugin', () => {
+    describe('plugin-verification', () => {
+      test.stderr().it('outputs nothing for just core plugins', ctx => {
+        ctx.config = getFakeConfig();
+
+        pluginFunc.call(ctx, getApiPlugin());
+
+        expect(ctx.stderr).to.be.empty;
+      });
+
+      test.stderr().it('outputs nothing if no conflicts in installed plugins', ctx => {
+        ctx.config = getFakeConfig();
+        ctx.config.plugins.push(getConformingPlugin());
+
+        pluginFunc.call(ctx, getApiPlugin());
+
+        expect(ctx.stderr).to.be.empty;
+      });
+
+      test.stderr().it('warns for each conflicting command', ctx => {
+        ctx.config = getFakeConfig();
+        ctx.config.plugins.push(getConflictingPlugin());
+
+        pluginFunc.call(ctx, getApiPlugin());
+
+        expect(ctx.stderr).to.contain('logon');
+        expect(ctx.stderr).to.contain('feedback');
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.


Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
# Fixes # 

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I updated my branch with the master branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added in line documentation to the code I modified

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

### Short description of what this PR does:
- If a plugin is installed that contains a command or alias that conflicts with another plugin or the core CLI, a warning is displayed to the user indicating the offending plugin and the command or alias.

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a Github Issue in this repository.


