### PR TITLE
Add --skip-parameter-validation flag

### DIFF
--- a/src/base-commands/twilio-api-command.js
+++ b/src/base-commands/twilio-api-command.js
@@ -45,7 +45,15 @@ class TwilioApiCommand extends TwilioClientCommand {
   }
 }
 
-TwilioApiCommand.flags = TwilioClientCommand.flags;
+TwilioApiCommand.flags = Object.assign(
+  {
+    'skip-parameter-validation': flags.boolean({
+      default: false,
+      hidden: true
+    })
+  },
+  TwilioClientCommand.flags
+);
 
 // A static function to help us add the other static
 // fields required by oclif on our dynamically created

--- a/src/services/twilio-api/api-command-runner.js
+++ b/src/services/twilio-api/api-command-runner.js
@@ -44,7 +44,7 @@ class ApiCommandRunner {
 
     // If there were any errors validating the flag values, log them by flag
     // key and throw.
-    if (Object.keys(flagErrors).length > 0) {
+    if (Object.keys(flagErrors).length > 0 && !this.flagValues['skip-parameter-validation']) {
       logger.error('Flag value validation errors:');
       Object.keys(flagErrors).forEach(key => {
         flagErrors[key].forEach(error => {


### PR DESCRIPTION
### Checklist
* [x] I acknowledge that all my contributions will be made under the project's license
* [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
* [x] I updated my branch with the master branch.
* [x] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation about the functionality in the appropriate .md file
* [ ] I have added in line documentation to the code I modified

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

### Short description of what this PR does:
- Adds a hidden `--skip-parameter-validation` flag to API commands
- This aids our automated Tricorder testing since dummy parameter values don't always match the validation criteria

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a Github Issue in this repository.


