### PR TITLE
fix: Don't overwrite parameters when building request

### DIFF
--- a/src/services/twilio-api/api-command-runner.js
+++ b/src/services/twilio-api/api-command-runner.js
@@ -96,7 +96,8 @@ class ApiCommandRunner {
   addParameter(parameter, params) {
     const flag = getFlagConfig(parameter, this.actionDefinition);
 
-    if (doesObjectHaveProperty(this.flagValues, flag.name)) {
+    // Add the param if it does't exist already and we have a value to add.
+    if (!doesObjectHaveProperty(params, parameter.name) && doesObjectHaveProperty(this.flagValues, flag.name)) {
       params[parameter.name] = this.flagValues[flag.name];
     }
   }

--- a/test/base-commands/twilio-api-command.test.js
+++ b/test/base-commands/twilio-api-command.test.js
@@ -176,6 +176,7 @@ describe('base-commands', () => {
         .stderr()
         .twilioCreateCommand(getCommandClass(numberUpdateActionDefinition), [
           '--sid', fakeCallResponse.sid,
+          '--account-sid', 'AC012',
           '--target-account-sid', 'AC123'
         ])
         .do(ctx => {


### PR DESCRIPTION
In the case of 'target-account-sid', it was being overwritten by 'account-sid'
if both flags were provided. 'account-sid' should already be captured by the
path parameter.