### PR TITLE
feat: sanity check the account SID and auth token when creating profiles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ Before you submit your pull request consider the following guidelines:
   * `cd ..`
   * `git clone https://github.com/twilio/twilio-cli.git`
   * `cd twilio-cli`
-  * In `package.json` replace `@twilio/cli-core": "<Version Number>"` with `@twilio/cli-core": "file:../twilio-cli-core`
+  * In `package.json` replace `"@twilio/cli-core": "<Version Number>"` with `"@twilio/cli-core": "file:../twilio-cli-core"`
   * `make clean install`
   * Test that everything is wired up correctuly with `./bin/run`
 

--- a/src/commands/profiles/create.js
+++ b/src/commands/profiles/create.js
@@ -81,13 +81,21 @@ class ProfilesCreate extends BaseCommand {
     }
   }
 
+  validateAuthTokenLength(input) {
+    if (input.length > 32) {
+      this.logger.error('Please double check your auth token, you may have pasted it more than once. Please re-enter your auth token or press enter to continue.');
+      return false;
+    }
+    return true;
+  }
+
   validateAuthToken() {
     if (!this.authToken) {
       this.questions.push({
         type: 'password',
         name: 'authToken',
         message: this.getPromptMessage(ProfilesCreate.flags['auth-token'].description),
-        validate: input => Boolean(input)
+        validate: input => this.validateAuthTokenLength(input)
       });
     }
   }
@@ -167,9 +175,6 @@ class ProfilesCreate extends BaseCommand {
       return true;
     } catch (err) {
       this.logger.error('Could not validate the provided credentials. Not saving.');
-      if (this.authToken.length > 32) {
-        this.logger.error('Please double check your auth token, you may have pasted it more than once.');
-      }
       this.logger.debug(err);
       return false;
     }

--- a/src/commands/profiles/create.js
+++ b/src/commands/profiles/create.js
@@ -167,6 +167,9 @@ class ProfilesCreate extends BaseCommand {
       return true;
     } catch (err) {
       this.logger.error('Could not validate the provided credentials. Not saving.');
+      if (this.authToken.length > 32) {
+        this.logger.error('Please double check your auth token, you may have pasted it more than once.');
+      }
       this.logger.debug(err);
       return false;
     }

--- a/src/commands/profiles/create.js
+++ b/src/commands/profiles/create.js
@@ -1,4 +1,3 @@
-const chalk = require('chalk');
 const os = require('os');
 const { flags } = require('@oclif/command');
 
@@ -14,6 +13,8 @@ const FRIENDLY_STORAGE_LOCATIONS = {
   [STORAGE_LOCATIONS.WIN_CRED_VAULT]: 'in the Windows credential vault',
   [STORAGE_LOCATIONS.LIBSECRET]: 'using libsecret'
 };
+
+const SKIP_VALIDATION = 'skip-parameter-validation';
 
 class ProfilesCreate extends BaseCommand {
   constructor(argv, config, secureStorage) {
@@ -39,8 +40,8 @@ class ProfilesCreate extends BaseCommand {
       this.cancel();
     }
 
-    this.validateAccountSid();
-    this.validateAuthToken();
+    this.loadAccountSid();
+    this.loadAuthToken();
     await this.promptForCredentials();
 
     if (await this.validateCredentials()) {
@@ -52,8 +53,6 @@ class ProfilesCreate extends BaseCommand {
   }
 
   loadArguments() {
-    this.accountSid = this.args['account-sid'];
-    this.authToken = this.flags['auth-token'];
     this.profileId = this.flags.profile;
     this.force = this.flags.force;
     this.region = this.flags.region;
@@ -72,37 +71,59 @@ class ProfilesCreate extends BaseCommand {
     }
   }
 
-  validateAccountSid() {
+  loadAccountSid() {
+    this.accountSid = this.args['account-sid'];
     if (!this.accountSid) {
       this.questions.push({
         name: 'accountSid',
         message: this.getPromptMessage(ProfilesCreate.args[0].description),
-        validate: input => Boolean(input)
+        validate: input => this.validAccountSid(input)
       });
     }
   }
 
-  validateAuthTokenLength(input) {
-    if (input.length > 32) {
-      this.logger.error('\nThe entered auth token is not of the standard length.\nPlease double-check the auth token and re-key it, or ' + chalk.red.bold('[press enter to continue as-is]') + '.');
-      return false;
-    }
-    return true;
-  }
-
-  validateAuthToken() {
+  loadAuthToken() {
+    this.authToken = this.flags['auth-token'];
     if (!this.authToken) {
       this.questions.push({
         type: 'password',
         name: 'authToken',
         message: this.getPromptMessage(ProfilesCreate.flags['auth-token'].description),
-        validate: input => this.validateAuthTokenLength(input)
+        validate: input => this.validAuthToken(input)
       });
     }
   }
 
+  validAccountSid(input) {
+    if (!input) {
+      return false;
+    }
+
+    if (!this.flags[SKIP_VALIDATION]) {
+      if (!input.startsWith('AC') || input.length !== 34) {
+        return 'Account SID must be "AC" followed by 32 hexadecimal digits (0-9, a-z)';
+      }
+    }
+
+    return true;
+  }
+
+  validAuthToken(input) {
+    if (!input) {
+      return false;
+    }
+
+    if (!this.flags[SKIP_VALIDATION]) {
+      if (input.length !== 32) {
+        return 'Auth Token must be 32 characters in length';
+      }
+    }
+
+    return true;
+  }
+
   async promptForCredentials() {
-    if (this.questions) {
+    if (this.questions && this.questions.length > 0) {
       this.logger.info(helpMessages.WHERE_TO_FIND_ACCOUNT_SID);
       this.logger.error(helpMessages.AUTH_TOKEN_NOT_SAVED);
       const answers = await this.inquirer.prompt(this.questions);
@@ -110,9 +131,14 @@ class ProfilesCreate extends BaseCommand {
       this.authToken = answers.authToken || this.authToken;
     }
 
-    if (!this.accountSid.toUpperCase().startsWith('AC')) {
-      throw new TwilioCliError('Account SID must be "AC" followed by 32 hexadecimal digits (0-9, a-z)');
-    }
+    const throwIfInvalid = valid => {
+      if (valid !== true) {
+        throw new TwilioCliError(valid || 'You must provide a valid value');
+      }
+    };
+
+    throwIfInvalid(this.validAccountSid(this.accountSid));
+    throwIfInvalid(this.validAuthToken(this.authToken));
   }
 
   async confirmOverwrite() {
@@ -223,6 +249,10 @@ ProfilesCreate.flags = Object.assign(
     force: flags.boolean({
       char: 'f',
       description: 'Force overwriting existing profile credentials.'
+    }),
+    [SKIP_VALIDATION]: flags.boolean({
+      default: false,
+      hidden: true
     }),
     region: flags.string({
       hidden: true

--- a/src/commands/profiles/create.js
+++ b/src/commands/profiles/create.js
@@ -1,3 +1,4 @@
+const chalk = require('chalk');
 const os = require('os');
 const { flags } = require('@oclif/command');
 
@@ -83,7 +84,7 @@ class ProfilesCreate extends BaseCommand {
 
   validateAuthTokenLength(input) {
     if (input.length > 32) {
-      this.logger.error('Please double check your auth token, you may have pasted it more than once. Please re-enter your auth token or press enter to continue.');
+      this.logger.error('\nThe entered auth token is not of the standard length.\nPlease double-check the auth token and re-key it, or ' + chalk.red.bold('[press enter to continue as-is]') + '.');
       return false;
     }
     return true;

--- a/test/commands/profiles/create.test.js
+++ b/test/commands/profiles/create.test.js
@@ -88,17 +88,17 @@ describe('commands', () => {
       // createTest()
       //   .do(ctx => {
       //     const fakePrompt = ctx.testCmd.inquirer.prompt;
-      //     fakePrompt.onThirdCall().resolves({
+      //     fakePrompt.onSecondCall().resolves({
       //       accountSid: constants.FAKE_ACCOUNT_SID,
-      //       authToken: constants.FAKE_API_SECRET.repeat(3)
+      //       authToken: constants.FAKE_API_SECRET.repeat(4)
       //     });
-
+      //
       //     return ctx.testCmd.run();
       //   })
       //   .exit(1)
       //   .it('fails for a too long auth token', ctx => {
       //     expect(ctx.stdout).to.equal('');
-      //     expect(ctx.stderr).to.contain('Please double check your auth token, you may have pasted it more than once.');
+      //     expect(ctx.stderr).to.contain('Please double check your auth token, you may have pasted it more than once.  Please re-enter your auth token or press enter to continue.');
       //   });
 
       createTest()

--- a/test/commands/profiles/create.test.js
+++ b/test/commands/profiles/create.test.js
@@ -85,21 +85,21 @@ describe('commands', () => {
         .catch(/Account SID must be "AC"/)
         .it('fails for invalid account SIDs');
 
-      createTest()
-        .do(ctx => {
-          const fakePrompt = ctx.testCmd.inquirer.prompt;
-          fakePrompt.onThirdCall().resolves({
-            accountSid: constants.FAKE_ACCOUNT_SID,
-            authToken: constants.FAKE_API_SECRET.repeat(3)
-          });
+      // createTest()
+      //   .do(ctx => {
+      //     const fakePrompt = ctx.testCmd.inquirer.prompt;
+      //     fakePrompt.onThirdCall().resolves({
+      //       accountSid: constants.FAKE_ACCOUNT_SID,
+      //       authToken: constants.FAKE_API_SECRET.repeat(3)
+      //     });
 
-          return ctx.testCmd.run();
-        })
-        .exit(1)
-        .it('fails for a too long auth token', ctx => {
-          expect(ctx.stdout).to.equal('');
-          expect(ctx.stderr).to.contain('Please double check your auth token, you may have pasted it more than once.');
-        });
+      //     return ctx.testCmd.run();
+      //   })
+      //   .exit(1)
+      //   .it('fails for a too long auth token', ctx => {
+      //     expect(ctx.stdout).to.equal('');
+      //     expect(ctx.stderr).to.contain('Please double check your auth token, you may have pasted it more than once.');
+      //   });
 
       createTest()
         .do(ctx => {

--- a/test/commands/profiles/create.test.js
+++ b/test/commands/profiles/create.test.js
@@ -87,6 +87,22 @@ describe('commands', () => {
 
       createTest()
         .do(ctx => {
+          const fakePrompt = ctx.testCmd.inquirer.prompt;
+          fakePrompt.onThirdCall().resolves({
+            accountSid: constants.FAKE_ACCOUNT_SID,
+            authToken: constants.FAKE_API_SECRET.repeat(3)
+          });
+
+          return ctx.testCmd.run();
+        })
+        .exit(1)
+        .it('fails for a too long auth token', ctx => {
+          expect(ctx.stdout).to.equal('');
+          expect(ctx.stderr).to.contain('Please double check your auth token, you may have pasted it more than once.');
+        });
+
+      createTest()
+        .do(ctx => {
           process.env.TWILIO_ACCOUNT_SID = constants.FAKE_ACCOUNT_SID;
           process.env.TWILIO_API_KEY = constants.FAKE_API_KEY;
           process.env.TWILIO_API_SECRET = constants.FAKE_API_SECRET;

--- a/test/commands/profiles/create.test.js
+++ b/test/commands/profiles/create.test.js
@@ -30,22 +30,24 @@ describe('commands', () => {
               .onThirdCall()
               .resolves({
                 accountSid: constants.FAKE_ACCOUNT_SID,
-                authToken: constants.FAKE_API_SECRET
+                authToken: '0'.repeat(32)
               });
             ctx.testCmd.inquirer.prompt = fakePrompt;
             ctx.testCmd.secureStorage.loadKeytar = sinon.fake.resolves(true);
           });
 
+      const mockSuccess = api => {
+        api.get(`/2010-04-01/Accounts/${constants.FAKE_ACCOUNT_SID}.json`).reply(200, {
+          sid: constants.FAKE_ACCOUNT_SID
+        });
+        api.post(`/2010-04-01/Accounts/${constants.FAKE_ACCOUNT_SID}/Keys.json`).reply(200, {
+          sid: constants.FAKE_API_KEY,
+          secret: constants.FAKE_API_SECRET
+        });
+      };
+
       createTest()
-        .nock('https://api.twilio.com', api => {
-          api.get(`/2010-04-01/Accounts/${constants.FAKE_ACCOUNT_SID}.json`).reply(200, {
-            sid: constants.FAKE_ACCOUNT_SID
-          });
-          api.post(`/2010-04-01/Accounts/${constants.FAKE_ACCOUNT_SID}/Keys.json`).reply(200, {
-            sid: constants.FAKE_API_KEY,
-            secret: constants.FAKE_API_SECRET
-          });
-        })
+        .nock('https://api.twilio.com', mockSuccess)
         .do(ctx => ctx.testCmd.run())
         .it('runs profiles:create', ctx => {
           expect(ctx.stdout).to.equal('');
@@ -85,21 +87,34 @@ describe('commands', () => {
         .catch(/Account SID must be "AC"/)
         .it('fails for invalid account SIDs');
 
-      // createTest()
-      //   .do(ctx => {
-      //     const fakePrompt = ctx.testCmd.inquirer.prompt;
-      //     fakePrompt.onSecondCall().resolves({
-      //       accountSid: constants.FAKE_ACCOUNT_SID,
-      //       authToken: constants.FAKE_API_SECRET.repeat(4)
-      //     });
-      //
-      //     return ctx.testCmd.run();
-      //   })
-      //   .exit(1)
-      //   .it('fails for a too long auth token', ctx => {
-      //     expect(ctx.stdout).to.equal('');
-      //     expect(ctx.stderr).to.contain('Please double check your auth token, you may have pasted it more than once.  Please re-enter your auth token or press enter to continue.');
-      //   });
+      createTest()
+        .do(ctx => {
+          const fakePrompt = ctx.testCmd.inquirer.prompt;
+          fakePrompt.onThirdCall().resolves({
+            accountSid: constants.FAKE_ACCOUNT_SID,
+            authToken: '0'
+          });
+
+          return ctx.testCmd.run();
+        })
+        .catch(/Auth Token must be 32/)
+        .it('fails for invalid Auth Tokens');
+
+      createTest(['--skip-parameter-validation'])
+        .nock('https://api.twilio.com', mockSuccess)
+        .do(ctx => {
+          const fakePrompt = ctx.testCmd.inquirer.prompt;
+          fakePrompt.onThirdCall().resolves({
+            accountSid: constants.FAKE_ACCOUNT_SID,
+            authToken: 'blurgh'
+          });
+
+          return ctx.testCmd.run();
+        })
+        .it('can skip parameter validation', ctx => {
+          expect(ctx.stdout).to.equal('');
+          expect(ctx.stderr).to.contain('configuration saved');
+        });
 
       createTest()
         .do(ctx => {
@@ -155,15 +170,7 @@ describe('commands', () => {
         .it('fails early if keytar cannot be loaded');
 
       createTest(['--region', 'dev'])
-        .nock('https://api.dev.twilio.com', api => {
-          api.get(`/2010-04-01/Accounts/${constants.FAKE_ACCOUNT_SID}.json`).reply(200, {
-            sid: constants.FAKE_ACCOUNT_SID
-          });
-          api.post(`/2010-04-01/Accounts/${constants.FAKE_ACCOUNT_SID}/Keys.json`).reply(200, {
-            sid: constants.FAKE_API_KEY,
-            secret: constants.FAKE_API_SECRET
-          });
-        })
+        .nock('https://api.dev.twilio.com', mockSuccess)
         .do(async ctx => ctx.testCmd.run())
         .it('supports other regions', ctx => {
           expect(ctx.stdout).to.equal('');


### PR DESCRIPTION
# Fixes #

It is difficult to debug when a user pastes their auth token more than once. This PR provides some guidance when we detect a non-standard length auth token.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the master branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified
