### PR TITLE
feat: update the mechanics of the login command

### DIFF
--- a/src/commands/profiles/create.js
+++ b/src/commands/profiles/create.js
@@ -34,17 +34,13 @@ class ProfilesCreate extends BaseCommand {
     await this.secureStorage.loadKeytar();
 
     this.loadArguments();
-    await this.promptForProfileId();
-
-    if (!(await this.confirmProfileAndEnvVars()) || !(await this.confirmOverwrite())) {
-      this.cancel();
-    }
 
     this.loadAccountSid();
     this.loadAuthToken();
     await this.promptForCredentials();
 
     if (await this.validateCredentials()) {
+      await this.loadProfileId();
       await this.saveCredentials();
       this.logger.info(`Saved ${this.profileId}.`);
     } else {
@@ -53,21 +49,27 @@ class ProfilesCreate extends BaseCommand {
   }
 
   loadArguments() {
-    this.profileId = this.flags.profile;
     this.force = this.flags.force;
     this.region = this.flags.region;
   }
 
-  async promptForProfileId() {
+  async loadProfileId() {
+    this.profileId = this.flags.profile;
     if (!this.profileId) {
       const answer = await this.inquirer.prompt([
         {
           name: 'profileId',
           message: this.getPromptMessage(ProfilesCreate.flags.profile.description),
-          validate: input => Boolean(input)
+          validate: input => Boolean(input.trim())
         }
       ]);
       this.profileId = answer.profileId;
+    }
+
+    this.profileId = this.profileId.trim();
+
+    if (!(await this.confirmProfileAndEnvVars()) || !(await this.confirmOverwrite())) {
+      this.cancel();
     }
   }
 
@@ -239,12 +241,12 @@ class ProfilesCreate extends BaseCommand {
 }
 
 ProfilesCreate.aliases = ['profiles:add', 'login'];
-ProfilesCreate.description = 'create a new profile to store Twilio Project credentials and configuration';
+ProfilesCreate.description = 'create a new profile to store Twilio Account credentials and configuration';
 
 ProfilesCreate.flags = Object.assign(
   {
     'auth-token': flags.string({
-      description: 'Your Twilio Auth Token for your Twilio Project.'
+      description: 'Your Twilio Auth Token for your Twilio Account or Subaccount.'
     }),
     force: flags.boolean({
       char: 'f',
@@ -264,7 +266,7 @@ ProfilesCreate.flags = Object.assign(
 ProfilesCreate.args = [
   {
     name: 'account-sid',
-    description: 'The Account SID for your Twilio Project.'
+    description: 'The Account SID for your Twilio Account or Subaccount.'
   }
 ];
 

--- a/src/services/messaging/help-messages.js
+++ b/src/services/messaging/help-messages.js
@@ -1,6 +1,6 @@
 const WHERE_TO_FIND_ACCOUNT_SID = 'You can find your Account SID and Auth Token at https://www.twilio.com/console';
 const AUTH_TOKEN_NOT_SAVED =
-  'Your Auth Token will be used once to create an API Key for future CLI access to your Twilio Project, and then forgotten.';
+  'Your Auth Token will be used once to create an API Key for future CLI access to your Twilio Account or Subaccount, and then forgotten.';
 
 module.exports = {
   WHERE_TO_FIND_ACCOUNT_SID,

--- a/test/commands/profiles/create.test.js
+++ b/test/commands/profiles/create.test.js
@@ -21,16 +21,16 @@ describe('commands', () => {
             fakePrompt
               .onFirstCall()
               .resolves({
-                profileId
+                accountSid: constants.FAKE_ACCOUNT_SID,
+                authToken: '0'.repeat(32)
               })
               .onSecondCall()
               .resolves({
-                overwrite: true
+                profileId
               })
               .onThirdCall()
               .resolves({
-                accountSid: constants.FAKE_ACCOUNT_SID,
-                authToken: '0'.repeat(32)
+                overwrite: true
               });
             ctx.testCmd.inquirer.prompt = fakePrompt;
             ctx.testCmd.secureStorage.loadKeytar = sinon.fake.resolves(true);
@@ -78,7 +78,7 @@ describe('commands', () => {
       createTest(['not-an-account-sid'])
         .do(ctx => {
           const fakePrompt = ctx.testCmd.inquirer.prompt;
-          fakePrompt.onThirdCall().resolves({
+          fakePrompt.onFirstCall().resolves({
             authToken: constants.FAKE_API_SECRET
           });
 
@@ -90,7 +90,7 @@ describe('commands', () => {
       createTest()
         .do(ctx => {
           const fakePrompt = ctx.testCmd.inquirer.prompt;
-          fakePrompt.onThirdCall().resolves({
+          fakePrompt.onFirstCall().resolves({
             accountSid: constants.FAKE_ACCOUNT_SID,
             authToken: '0'
           });
@@ -104,7 +104,7 @@ describe('commands', () => {
         .nock('https://api.twilio.com', mockSuccess)
         .do(ctx => {
           const fakePrompt = ctx.testCmd.inquirer.prompt;
-          fakePrompt.onThirdCall().resolves({
+          fakePrompt.onFirstCall().resolves({
             accountSid: constants.FAKE_ACCOUNT_SID,
             authToken: 'blurgh'
           });
@@ -123,7 +123,7 @@ describe('commands', () => {
           process.env.TWILIO_API_SECRET = constants.FAKE_API_SECRET;
 
           const fakePrompt = ctx.testCmd.inquirer.prompt;
-          fakePrompt.onSecondCall().resolves({
+          fakePrompt.onThirdCall().resolves({
             affirmative: false
           });
 


### PR DESCRIPTION
* change 'Twilio Project' to 'Twilio Account or Subaccount'
* trim leading/trailing whitespace from profile ID
* move the profile ID entry to last (after account and auth token)