### PR TITLE
fix: added in @oclif/color 0.1.0 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "bugs": "https://github.com/twilio/twilio-cli/issues",
   "dependencies": {
+    "@oclif/color": "^0.1.0",
     "@oclif/command": "^1.5.19",
     "@oclif/config": "^1.14.0",
     "@oclif/plugin-autocomplete": "^0.1.5",


### PR DESCRIPTION
# Fixes #

This fixes error on listing plugin listed in oclif/plugin-plugins repo, https://github.com/oclif/plugin-plugins/issues/86:

Before:
```
./bin/run plugins
TypeError: Cannot read property 'dim' of undefined
    at Object.<anonymous> (~/code/twilio-cli/node_modules/@oclif/color/lib/index.js:10:86)
    at Object.<anonymous> (~/code/twilio-cli/node_modules/@oclif/plugin-plugins/lib/commands/plugins/index.js:3:17)
```
After:
```
./bin/run plugins
@dabblelab/plugin-autopilot 1.0.2
@twilio-labs/plugin-rtc 0.1.4
@twilio-labs/plugin-serverless 1.3.0
@twilio-labs/plugin-watch 2.0.3
```
### Checklist
- [X] I acknowledge that all my contributions will be made under the project's license
- [X] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [X] I have read the [Contribution Guidelines](CONTRIBUTING.md) and my PR follows them
- [X] I have titled the PR appropriately
- [X] I have updated my branch with the master branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
