### PR TITLE
feat: move Twilio (Sub)Account APIs to their own topic

### DIFF
--- a/src/services/twilio-api/get-topic-name.js
+++ b/src/services/twilio-api/get-topic-name.js
@@ -12,8 +12,10 @@ const getTopicName = actionDefinition => {
         .replace(/\.json$/, '') // Drop the JSON extension
         .replace(/\/{.+?}/g, '') // Drop every {PathParameter}
         .replace(/\/+/g, TOPIC_SEPARATOR) // Separate paths with topic separator
-    )
-  ).replace(/api:2010-04-01:accounts/, CORE_TOPIC_NAME); // Chop the legacy API version down
+    ))
+    // Chop the legacy API version down
+    .replace(/api:2010-04-01:accounts(?=:)/, CORE_TOPIC_NAME) // First non-account level APIs
+    .replace(/api:2010-04-01/, CORE_TOPIC_NAME); // Then account APIs (i.e., modifying Twilio accounts or subaccounts)
 };
 
 module.exports = {

--- a/test/services/twilio-api.test.js
+++ b/test/services/twilio-api.test.js
@@ -18,6 +18,18 @@ describe('services', () => {
           path: '/v1/Bars/{BarId}/SubBars/{SubBarId}.json'
         })).to.equal('foo:v1:bars:sub-bars');
       });
+
+      test.it('handles v2010 APIs', () => {
+        expect(getTopicName({
+          domainName: 'api',
+          path: '/2010-04-01/Accounts/{Sid}.json'
+        })).to.equal('core:accounts');
+
+        expect(getTopicName({
+          domainName: 'api',
+          path: '/2010-04-01/Accounts/{AccountSid}/Addresses/{Sid}.json'
+        })).to.equal('core:addresses');
+      });
     });
 
     describe('getActionDescription', () => {


### PR DESCRIPTION
The account create, fetch, list, and update commands were previously under the 'api:core' topic (mixed in with other topics). This change moves the to under their  own 'api:core:accounts' topic.

Before:
```
➜ twilio api:core
resources under api.twilio.com

USAGE
  $ twilio api:core:COMMAND

COMMANDS
  api:core:addresses                An Address instance resource represents your or your customerâ€™s physical location within a country. Around the world, some
                                    local authorities require the name and address of the user to be on file with Twilio to purchase and own a phone number.
  api:core:applications             An Application instance resource represents an application that you have created with Twilio. An application inside of Twilio
                                    is just a set of URLs and other configuration data that tells Twilio how to behave when one of your Twilio numbers receives a
                                    call or SMS message.
  api:core:authorized-connect-apps  Authorized Twilio Connect apps
  api:core:available-phone-numbers  Country codes with available phone numbers
  api:core:balance                  Account balance
  api:core:calls                    A Call is an object that represents a connection between a telephone and Twilio.
  api:core:conferences              Voice call conferences
  api:core:connect-apps             Twilio Connect apps
  api:core:create                   Create a new Twilio Subaccount from the account making the request
  api:core:fetch                    Fetch the account specified by the provided Account Sid
  api:core:incoming-phone-numbers   Incoming phone numbers on a Twilio account/project
  api:core:keys                     API keys
  api:core:list                     Retrieves a collection of Accounts belonging to the account used to make the request
  api:core:messages                 A Message resource represents an inbound or outbound message.
  api:core:notifications            [DEPRECATED] Log entries
  api:core:outgoing-caller-ids      An OutgoingCallerId resource represents a single verified number that may be used as a caller ID when making outgoing calls
                                    via the REST API and within the TwiML <Dial> verb.
  api:core:queues                   Queues of calls
  api:core:recordings               Recordings of phone calls
  api:core:signing-keys             Create a new signing key
  api:core:sip                      Create a Credential List
  api:core:sms                      Retrieve a list of short-codes belonging to the account used to make the request
  api:core:tokens                   Credentials for ICE servers
  api:core:transcriptions           Text transcriptions of call recordings
  api:core:update                   Modify the properties of a given Account
  api:core:usage                    Retrieve a list of usage-records belonging to the account used to make the request
```

After:
```
➜ twilio api:core
resources under api.twilio.com

USAGE
  $ twilio api:core:COMMAND

COMMANDS
  api:core:accounts                 Twilio accounts (aka Project) or subaccounts
  api:core:addresses                An Address instance resource represents your or your customerâ€™s physical location within a country. Around the world, some
                                    local authorities require the name and address of the user to be on file with Twilio to purchase and own a phone number.
  api:core:applications             An Application instance resource represents an application that you have created with Twilio. An application inside of Twilio
                                    is just a set of URLs and other configuration data that tells Twilio how to behave when one of your Twilio numbers receives a
                                    call or SMS message.
  api:core:authorized-connect-apps  Authorized Twilio Connect apps
  api:core:available-phone-numbers  Country codes with available phone numbers
  api:core:balance                  Account balance
  api:core:calls                    A Call is an object that represents a connection between a telephone and Twilio.
  api:core:conferences              Voice call conferences
  api:core:connect-apps             Twilio Connect apps
  api:core:incoming-phone-numbers   Incoming phone numbers on a Twilio account/project
  api:core:keys                     API keys
  api:core:messages                 A Message resource represents an inbound or outbound message.
  api:core:notifications            [DEPRECATED] Log entries
  api:core:outgoing-caller-ids      An OutgoingCallerId resource represents a single verified number that may be used as a caller ID when making outgoing calls
                                    via the REST API and within the TwiML <Dial> verb.
  api:core:queues                   Queues of calls
  api:core:recordings               Recordings of phone calls
  api:core:signing-keys             Create a new signing key
  api:core:sip                      Create a Credential List
  api:core:sms                      Retrieve a list of short-codes belonging to the account used to make the request
  api:core:tokens                   Credentials for ICE servers
  api:core:transcriptions           Text transcriptions of call recordings
  api:core:usage                    Retrieve a list of usage-records belonging to the account used to make the request

➜ twilio api:core:accounts
Twilio accounts (aka Project) or subaccounts

USAGE
  $ twilio api:core:accounts:COMMAND

COMMANDS
  api:core:accounts:create  Create a new Twilio Subaccount from the account making the request
  api:core:accounts:fetch   Fetch the account specified by the provided Account Sid
  api:core:accounts:list    Retrieves a collection of Accounts belonging to the account used to make the request
  api:core:accounts:update  Modify the properties of a given Account
```