### PR TITLE
feat: Makes file paths with tildes work for email:send

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6021,6 +6021,12 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
+    "tildify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tildify/-/tildify-2.0.0.tgz",
+      "integrity": "sha512-Cc+OraorugtXNfs50hU9KS369rFXCfgGLpfCfvlc+Ud5u6VWmUQsOAa9HbTvheQdYnrdJqqv1e5oIqXppMYnSw==",
+      "dev": true
+    },
     "tmp": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
@@ -6186,6 +6192,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
       "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
+    },
+    "untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw=="
     },
     "uri-js": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "chalk": "^4.1.0",
     "file-type": "^14.6.2",
     "inquirer": "^7.3.0",
-    "twilio": "^3.48.2"
+    "twilio": "^3.48.2",
+    "untildify": "^4.0.0"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.22.2",
@@ -64,6 +65,7 @@
     "nyc": "^15.1.0",
     "proxyquire": "^2.1.3",
     "sinon": "^9.0.2",
+    "tildify": "^2.0.0",
     "tmp": "^0.2.1"
   },
   "optionalDependencies": {

--- a/src/services/file-io.js
+++ b/src/services/file-io.js
@@ -3,6 +3,7 @@ const path = require('path');
 
 const { TwilioCliError } = require('@twilio/cli-core').services.error;
 const { logger } = require('@twilio/cli-core').services.logging;
+const untildify = require('untildify');
 
 function getStdin() {
   return new Promise((resolve) => {
@@ -16,14 +17,15 @@ function getStdin() {
 }
 
 function readFile(filePath, encoding) {
+  const resolvedFilePath = untildify(filePath);
   try {
     return {
-      filename: path.basename(filePath),
-      content: fs.readFileSync(filePath, encoding),
+      filename: path.basename(resolvedFilePath),
+      content: fs.readFileSync(resolvedFilePath, encoding),
     };
   } catch (error) {
     logger.debug(error);
-    throw new TwilioCliError(`Unable to read the file: ${filePath}`);
+    throw new TwilioCliError(`Unable to read the file: ${resolvedFilePath}`);
   }
 }
 

--- a/src/services/file-io.js
+++ b/src/services/file-io.js
@@ -17,15 +17,15 @@ function getStdin() {
 }
 
 function readFile(filePath, encoding) {
-  const resolvedFilePath = untildify(filePath);
   try {
+    const resolvedFilePath = untildify(filePath);
     return {
       filename: path.basename(resolvedFilePath),
       content: fs.readFileSync(resolvedFilePath, encoding),
     };
   } catch (error) {
     logger.debug(error);
-    throw new TwilioCliError(`Unable to read the file: ${resolvedFilePath}`);
+    throw new TwilioCliError(`Unable to read the file: ${filePath}`);
   }
 }
 

--- a/test/commands/email/send.test.js
+++ b/test/commands/email/send.test.js
@@ -1,6 +1,9 @@
+const { resolve } = require('path');
+
 const sinon = require('sinon');
 const { expect, test } = require('@twilio/cli-test');
 const { Config, ConfigData } = require('@twilio/cli-core').services.config;
+const tildify = require('tildify');
 
 const emailSend = require('../../../src/commands/email/send');
 
@@ -235,6 +238,15 @@ describe('commands', () => {
         .do((ctx) => ctx.testCmd.run())
         .catch(/Unable to read the file/)
         .it('run email:send using flags to set information using invalid file path');
+
+      defaultSetup({
+        toEmail: 'jen@test.com',
+        flags: ['--attachment', tildify(resolve('test/commands/email/test.txt'))],
+      })
+        .do((ctx) => ctx.testCmd.run())
+        .it('run email:send using flags to set information using tilde in file path', (ctx) => {
+          expect(ctx.stderr).to.contain('test.txt');
+        });
 
       defaultSetup({ toEmail: 'jen@test.com', attachmentVerdict: true })
         .do((ctx) => ctx.testCmd.run())


### PR DESCRIPTION
Supplying a file path for an email attachment with a tilde to mean the home directory when using email:send fails. Node.js doesn't support expanding `~` to `os.homedir()` by default, but the untildify package does create a safe way to achieve this.

I worked on this because I tried to send an attachment a number of times with files that definitely existed, but the CLI was telling me they couldn't be found. When I finally used an absolute path, it worked. I'd like to remove that frustration from anyone else that tries.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified