### PR TITLE
chore: remove preview gate

### DIFF
--- a/src/hooks/init/twilio-api.js
+++ b/src/hooks/init/twilio-api.js
@@ -42,10 +42,6 @@ class TwilioRestApiPlugin extends Plugin {
   }
 
   scanDomain(domainName) {
-    if (domainName === 'preview') {
-      return;
-    }
-
     const actionDefinition = {
       domainName,
       domain: this.apiBrowser.domains[domainName],


### PR DESCRIPTION
Related PR: https://github.com/twilio/twilio-cli-core/pull/116

Removes the code that masks the preview domain OpenAPI doc, since it will no longer be rendered in cli-core.

Note: The Travis build will knowingly fail until a new version of @twilio/cli-core is published to npm. This has been tested and passes locally when creating a link to a local version of cli-core in the `package.json`