### PR TITLE
feat: add assets plugin to available plugins

### DIFF
--- a/src/services/plugins.js
+++ b/src/services/plugins.js
@@ -7,6 +7,7 @@ const PLUGIN_COMMANDS = {
   '@twilio-labs/plugin-signal2020': ['signal', 'signal2020'],
   '@twilio-labs/plugin-token': ['token'],
   '@twilio-labs/plugin-watch': ['watch'],
+  '@twilio-labs/plugin-assets': ['assets'],
   '@dabblelab/plugin-autopilot': ['autopilot'],
 };
 


### PR DESCRIPTION
Recently released a new [plugin for using Twilio Assets from the CLI as part of the Serverless Toolkit](https://github.com/twilio-labs/serverless-toolkit/tree/main/packages/plugin-assets). This adds the plugin to the available plugins list.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-cli/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
