### PR TITLE
fix: correct a typo in config:set error messaging

### DIFF
--- a/src/commands/config/set.js
+++ b/src/commands/config/set.js
@@ -27,7 +27,7 @@ class ConfigSet extends BaseCommand {
     }
     if (isError) {
       throw new TwilioCliError(
-        `No configuration is added to set. Run "twilio configs:set --help" to see how to set a configurations.`,
+        `No configuration is added to set. Run "twilio config:set --help" to see how to set a configurations.`,
       );
     }
     if (isUserConfigUpdated) {

--- a/test/commands/config/set.test.js
+++ b/test/commands/config/set.test.js
@@ -117,7 +117,7 @@ describe('commands', () => {
 
       createConfig([], {})
         .do((ctx) => ctx.testCmd.run())
-        .catch(/No configuration is added to set. Run "twilio configs:set --help" to see how to set a configurations./)
+        .catch(/No configuration is added to set. Run "twilio config:set --help" to see how to set a configurations./)
         .it('runs config:set ,should throw error as there are no configurations/flags provided.');
     });
   });


### PR DESCRIPTION
# Fixes #

When a user enters invalid arguments to the `config:set` command, the error message mistakenly references an incorrect command name, `configs:set`:

```sh
$ twilio config:set
 » No configuration is added to set. Run "twilio configs:set --help" to see how to set a configurations.

$ twilio configs:set --help
 ›   Error: command configs:set not found

$ twilio config:set --help

update Twilio CLI configurations.

USAGE
  $ twilio config:set
...
```

This change corrects that mistake in the error message (along with the corresponding test).

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-cli/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified
