### PR TITLE
fix: Removing the gh release create step due to rpm build failure

### DIFF
--- a/.github/workflows/rpmbuild.yml
+++ b/.github/workflows/rpmbuild.yml
@@ -14,7 +14,7 @@ jobs:
         id: get-tag
         run: |
           echo "::set-output name=TAG_NAME::$(node -p -e "require('./package.json').version")"
-          
+
       - name: process version and release
         if: contains(steps.get-tag.outputs.TAG_NAME, 'rc' )
         id: process-release-version
@@ -22,13 +22,13 @@ jobs:
           releaseVersionString=${{ steps.get-tag.outputs.TAG_NAME}}
           echo "::set-output name=version::$(echo "$releaseVersionString" | cut -d- -f1)"
           echo "::set-output name=release::$(echo "$releaseVersionString" | cut -d- -f2-)"
-          
+
       - name: print version and release
         if: contains(steps.get-tag.outputs.TAG_NAME, 'rc' )
         run: |
           echo rpm_package_version: ${{ steps.process-release-version.outputs.VERSION }}
           echo rpm_package_release: ${{ steps.process-release-version.outputs.RELEASE }}
-          
+
       - name: generate linux tarball
         run: |
           make install
@@ -80,13 +80,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ "${{ github.ref_name }}" == "main" ]; then
-            gh release create ${{ steps.get-tag.outputs.TAG_NAME }}
             gh release upload ${{ steps.get-tag.outputs.TAG_NAME }} ${{ steps.build_rpm.outputs.rpm_package_path }} --clobber
           else
-            gh release create ${{ steps.get-tag.outputs.TAG_NAME }}
             gh release upload ${{ steps.get-tag.outputs.TAG_NAME }} ${{ steps.build_rpm_rc_release.outputs.rpm_package_path }} --clobber
           fi
-          
+
   notify-complete-fail:
     if: ${{ failure() || cancelled() }}
     needs: [ rpmbuild ]


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

# Fixes #
RPM build failure in CLI release
A short description of what this PR does.
Removing the gh release create step due to rpm build failure
### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [ ] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-cli/blob/main/CONTRIBUTING.md) and my PR follows them
- [ ] I have titled the PR appropriately
- [ ] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
