### PR TITLE
fix: Use xz compression to restore Debian stable support

### DIFF
--- a/.github/scripts/pack-debian-apt.js
+++ b/.github/scripts/pack-debian-apt.js
@@ -81,6 +81,7 @@ PATH=$PATH:$PWD/bin eval $(PATH=$PATH:$PWD/bin node -p "require('./package').scr
       await qq.chmod([workspace, 'usr/lib', config.dirname, 'bin', config.bin], 0o755);
       await qq.chmod([workspace, 'DEBIAN/postinst'], 0o755);
       await qq.x(`ln -s "../lib/${config.dirname}/bin/${config.bin}" "${workspace}/usr/bin/${pjson.oclif.bin}"`);
+      // Use xz compression until Debian supports zstd (see issue #482)
       await qq.x(`dpkg --build --compression=xz "${workspace}" "${qq.join(dist, debArch(arch), `${versionedDebBase}.deb`)}"`);
     }
     try {

--- a/.github/scripts/pack-debian-apt.js
+++ b/.github/scripts/pack-debian-apt.js
@@ -81,7 +81,7 @@ PATH=$PATH:$PWD/bin eval $(PATH=$PATH:$PWD/bin node -p "require('./package').scr
       await qq.chmod([workspace, 'usr/lib', config.dirname, 'bin', config.bin], 0o755);
       await qq.chmod([workspace, 'DEBIAN/postinst'], 0o755);
       await qq.x(`ln -s "../lib/${config.dirname}/bin/${config.bin}" "${workspace}/usr/bin/${pjson.oclif.bin}"`);
-      await qq.x(`dpkg --build "${workspace}" "${qq.join(dist, debArch(arch), `${versionedDebBase}.deb`)}"`);
+      await qq.x(`dpkg --build --compression=xz "${workspace}" "${qq.join(dist, debArch(arch), `${versionedDebBase}.deb`)}"`);
     }
     try {
       // fetch existing Packages file which needs to be modified for new version


### PR DESCRIPTION
The default compression on deb packages seems to have changed to zstd. Unfortunately, Debian does not support zstd (yet), so this specifies a friendlier format.

Note that I don't know a good way to test this at the moment. I'm open to suggestions though.

Fixes #482

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-cli/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified