### PR TITLE
fix: use bundled node version for post install 

### DIFF
--- a/.github/scripts/pack-debian-apt.js
+++ b/.github/scripts/pack-debian-apt.js
@@ -44,7 +44,7 @@ APT::FTPArchive::Release::Suite "stable";
 `,
   postinst: () => `#!/usr/bin/env bash
 cd /usr/lib/twilio-cli
-PATH=$PATH:$PWD/bin eval $(PATH=$PATH:$PWD/bin node -p "require('./package').scripts.postinstall")
+PATH=$PWD/bin:$PATH eval $(PATH=$PWD/bin:$PATH node -p "require('./package').scripts.postinstall")
 `
 }
 


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

# Fixes #
twilio-cli throws an error when running the post-install script if the node version doesn't support optional chaining. Since it's already installing a full node runtime, it might as well use it for this.

```
root@eric-MS-7C02:~# apt-get upgrade -y
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Calculating upgrade... Done
...
Setting up twilio (5.14.0-1) ...
/usr/lib/twilio-cli/node_modules/@oclif/core/lib/command.js:41
            delete this.globalFlags?.json;
                                    ^

SyntaxError: Unexpected token '.'
    at wrapSafe (internal/modules/cjs/loader.js:915:16)
    at Module._compile (internal/modules/cjs/loader.js:963:27)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Module.require (internal/modules/cjs/loader.js:887:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at Object.<anonymous> (/usr/lib/twilio-cli/node_modules/@oclif/core/lib/index.js:6:19)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
dpkg: error processing package twilio (--configure):
 installed twilio package post-installation script subprocess returned error exit status 1
Errors were encountered while processing:
 twilio
E: Sub-process /usr/bin/dpkg returned an error code (1)
```

Made the edit to the post install script locally and it worked. Unsure of how to test the github action itself, so hopefully someone can help me with that.



### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-cli/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
