### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/scripts/trigger-and-wait.sh
+++ b/.github/scripts/trigger-and-wait.sh
@@ -102,8 +102,8 @@ wait_for_workflow_to_finish() {
   last_workflow_url="https://github.com/${INPUT_OWNER}/${INPUT_REPO}/actions/runs/${last_workflow_id}"
   echo "The workflow id is [${last_workflow_id}]."
   echo "The workflow logs can be found at ${last_workflow_url}"
-  echo "::set-output name=workflow_id::${last_workflow_id}"
-  echo "::set-output name=workflow_url::${last_workflow_url}"
+  echo "workflow_id=${last_workflow_id}" >> $GITHUB_OUTPUT
+  echo "workflow_url=${last_workflow_url}" >> $GITHUB_OUTPUT
   echo ""
   conclusion=$(echo "${last_workflow}" | jq '.conclusion')
   status=$(echo "${last_workflow}" | jq '.status')

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -38,7 +38,7 @@ jobs:
         id: get-tag
         run: |
           git fetch --prune --unshallow
-          echo "::set-output name=TAG_NAME::$(git describe --tags $(git rev-list --tags --max-count=1))"
+          echo "TAG_NAME=$(git describe --tags $(git rev-list --tags --max-count=1))" >> $GITHUB_OUTPUT
 
   wait-for-brew-releases:
     name: Wait for brew Release to complete
@@ -93,7 +93,7 @@ jobs:
       - name: setup brew failure output
         if: failure() || cancelled()
         id: failure_brew
-        run: echo '::set-output name=FAILURE_TAG_BREW::true'
+        run: echo "FAILURE_TAG_BREW=true" >> $GITHUB_OUTPUT
 
   wait-for-windows-releases:
     name: Wait for windows platform executables Release to complete
@@ -131,7 +131,7 @@ jobs:
       - name: setup windows failure output
         if: failure() || cancelled()
         id: failure_windows
-        run: echo '::set-output name=FAILURE_TAG_WINDOWS::true'
+        run: echo "FAILURE_TAG_WINDOWS=true" >> $GITHUB_OUTPUT
 
   wait-for-macos-releases:
     name: Wait for macos platform executables Release to complete
@@ -161,7 +161,7 @@ jobs:
       - name: setup macos failure output
         if: failure() || cancelled()
         id: failure_macos
-        run: echo '::set-output name=FAILURE_TAG_MACOS::true'
+        run: echo "FAILURE_TAG_MACOS=true" >> $GITHUB_OUTPUT
 
   wait-for-debian-releases:
     name: Wait for debian platform executables Release to complete
@@ -191,7 +191,7 @@ jobs:
       - name: setup debian failure output
         if: failure() || cancelled()
         id: failure_debian
-        run: echo '::set-output name=FAILURE_TAG_DEBIAN::true'
+        run: echo "FAILURE_TAG_DEBIAN=true" >> $GITHUB_OUTPUT
   test-apt-release:
     name: Wait for apt release to complete
     runs-on: ubuntu-latest
@@ -235,7 +235,7 @@ jobs:
       - name: setup apt failure output
         if: failure() || cancelled()
         id: failure_apt
-        run: echo '::set-output name=FAILURE_TAG_APT::true'
+        run: echo "FAILURE_TAG_APT=true" >> $GITHUB_OUTPUT
   test-npm-releases:
     name: NPM acceptance testing
     runs-on: ubuntu-latest
@@ -277,7 +277,7 @@ jobs:
       - name: setup debian failure output
         if: failure() || cancelled()
         id: failure_npm
-        run: echo '::set-output name=FAILURE_TAG_NPM::true'
+        run: echo "FAILURE_TAG_NPM=true" >> $GITHUB_OUTPUT
 
   test-scoop-release:
     name: Do scoop testing after release
@@ -320,7 +320,7 @@ jobs:
       - name: setup scoop failure output
         if: failure() || cancelled()
         id: failure_scoop
-        run: echo '::set-output name=FAILURE_TAG_SCOOP::true'
+        run: echo "FAILURE_TAG_SCOOP=true" >> $GITHUB_OUTPUT
 
   notify-complete-fail:
     needs: [wait-for-brew-releases, wait-for-windows-releases, wait-for-debian-releases, wait-for-macos-releases, test-scoop-release, test-npm-releases, test-apt-release]

--- a/.github/workflows/debian-draft-executable-release.yml
+++ b/.github/workflows/debian-draft-executable-release.yml
@@ -15,7 +15,7 @@ jobs:
         id: get-tag
         run: |
          git fetch --prune --unshallow
-         echo "::set-output name=TAG_NAME::$(git describe --tags $(git rev-list --tags --max-count=1))"
+         echo "TAG_NAME=$(git describe --tags $(git rev-list --tags --max-count=1))" >> $GITHUB_OUTPUT
       - run: |
           make install
           sudo npx oclif pack:deb

--- a/.github/workflows/debian-executable-release.yml
+++ b/.github/workflows/debian-executable-release.yml
@@ -13,12 +13,12 @@ jobs:
       - uses: actions/checkout@v2
       - name: Getting last sha
         id: get-sha
-        run: echo "::set-output name=SHA_SHORT::$(git rev-parse --short HEAD)"
+        run: echo "SHA_SHORT=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Getting latest tag
         id: get-tag
         run: |
          git fetch --prune --unshallow
-         echo "::set-output name=TAG_NAME::$(git describe --tags $(git rev-list --tags --max-count=1))"
+         echo "TAG_NAME=$(git describe --tags $(git rev-list --tags --max-count=1))" >> $GITHUB_OUTPUT
       - run: |
           make install
           sudo chown -R 1001:121 "/root/.npm"

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -13,7 +13,7 @@ jobs:
         id: get-tag
         run: |
           git fetch --tags
-          echo "::set-output name=TAG_NAME::$(git describe --tags $(git rev-list --tags --max-count=1))"
+          echo "TAG_NAME=$(git describe --tags $(git rev-list --tags --max-count=1))" >> $GITHUB_OUTPUT
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/macos-executable-release.yml
+++ b/.github/workflows/macos-executable-release.yml
@@ -16,7 +16,7 @@ jobs:
        id: get-tag
        run: |
         git fetch --prune --unshallow
-        echo "::set-output name=TAG_NAME::$(git describe --tags $(git rev-list --tags --max-count=1))"
+        echo "TAG_NAME=$(git describe --tags $(git rev-list --tags --max-count=1))" >> $GITHUB_OUTPUT
   get-sha:
     runs-on: macos-11
     outputs:
@@ -27,7 +27,7 @@ jobs:
         id: get-sha
         run: |
           git fetch --prune --unshallow
-          echo "::set-output name=SHA_SHORT::$(git rev-parse --short HEAD)"
+          echo "SHA_SHORT=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
   pack-macos:
     needs: [get-tag, get-sha]
     runs-on: macos-11

--- a/.github/workflows/oclif-release.yml
+++ b/.github/workflows/oclif-release.yml
@@ -53,11 +53,11 @@ jobs:
           npx oclif-dev publish
           brew install coreutils
           if [ "${{github.event.inputs.formula}}" == "twiliorc" ]; then
-            echo "::set-output name=sha256::$(sha256sum dist/channels/rc/${{ matrix.asset_name }}/${{ matrix.asset_name }}.tar.gz | awk '{print $1}')"
+            echo "sha256=$(sha256sum dist/channels/rc/${{ matrix.asset_name }}/${{ matrix.asset_name }}.tar.gz | awk '{print $1}')" >> $GITHUB_OUTPUT
           elif [ "${{github.event.inputs.formula}}" == "twiliodraft" ]; then
-            echo "::set-output name=sha256::$(sha256sum dist/channels/draft/${{ matrix.asset_name }}/${{ matrix.asset_name }}.tar.gz | awk '{print $1}')"
+            echo "sha256=$(sha256sum dist/channels/draft/${{ matrix.asset_name }}/${{ matrix.asset_name }}.tar.gz | awk '{print $1}')" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=sha256::$(sha256sum dist/${{ matrix.asset_name }}/${{ matrix.asset_name }}.tar.gz | awk '{print $1}')"
+            echo "sha256=$(sha256sum dist/${{ matrix.asset_name }}/${{ matrix.asset_name }}.tar.gz | awk '{print $1}')" >> $GITHUB_OUTPUT
           fi
   home-brew-release:
     name: Trigger homebrew release workflow

--- a/.github/workflows/rpmbuild.yml
+++ b/.github/workflows/rpmbuild.yml
@@ -13,7 +13,7 @@ jobs:
       - name: get version
         id: get-tag
         run: |
-          echo "::set-output name=TAG_NAME::$(node -p -e "require('./package.json').version")"
+          echo "TAG_NAME=$(node -p -e "require('./package.json').version")" >> $GITHUB_OUTPUT
 
       - name: generate linux tarball
         run: |

--- a/.github/workflows/windows-executable-draft-release.yml
+++ b/.github/workflows/windows-executable-draft-release.yml
@@ -21,7 +21,7 @@ jobs:
        id: get-tag
        run: |
         git fetch --prune --unshallow
-        echo "::set-output name=TAG_NAME::$(git describe --tags $(git rev-list --tags --max-count=1))"
+        echo "TAG_NAME=$(git describe --tags $(git rev-list --tags --max-count=1))" >> $GITHUB_OUTPUT
   pack-windows-release:
     runs-on: macos-latest
     needs: [get-tag]
@@ -29,7 +29,7 @@ jobs:
      - uses: actions/checkout@v2
      - name: Getting last sha
        id: get-sha
-       run: echo "::set-output name=SHA_SHORT::$(git rev-parse --short HEAD)"
+       run: echo "SHA_SHORT=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
      - run: |
         make install
         brew install makensis

--- a/.github/workflows/windows-executable-release.yml
+++ b/.github/workflows/windows-executable-release.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Getting latest sha
         id: get-sha
-        run: echo "::set-output name=SHA_SHORT::$(git rev-parse --short HEAD)"
+        run: echo "SHA_SHORT=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
   get-tag:
     runs-on: macos-latest
     outputs:
@@ -24,7 +24,7 @@ jobs:
        id: get-tag
        run: |
         git fetch --prune --unshallow
-        echo "::set-output name=TAG_NAME::$(git describe --tags $(git rev-list --tags --max-count=1))"
+        echo "TAG_NAME=$(git describe --tags $(git rev-list --tags --max-count=1))" >> $GITHUB_OUTPUT
   pack-windows-release:
     runs-on: macos-latest
     needs: [get-tag, get-sha]

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -92,7 +92,7 @@
     [
       "@semantic-release/exec",
       {
-        "successCmd": "echo '::set-output name=TAG_NAME::${nextRelease.version}'"
+        "successCmd": "echo 'TAG_NAME=${nextRelease.version}' >> $GITHUB_OUTPUT"
       }
     ]
   ]


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


