### PR TITLE
Skip plugin installation if already installed

### DIFF
--- a/src/hooks/plugin-install.js
+++ b/src/hooks/plugin-install.js
@@ -1,7 +1,6 @@
 const { logger } = require('@twilio/cli-core').services.logging;
 const chalk = require('chalk');
-
-const { isTwilioPlugin } = require('../services/plugins');
+const { isTwilioPlugin, isPluginInstalled } = require('../services/plugins');
 
 const AUTOCOMLETE_INSTALL_WARNING = `If you’re using autocomplete, you’ll need to run ${chalk.bold(
   'twilio autocomplete',
@@ -9,6 +8,11 @@ const AUTOCOMLETE_INSTALL_WARNING = `If you’re using autocomplete, you’ll ne
 
 module.exports = async function pluginInstall(options) {
   logger.warn(chalk.yellowBright(`${AUTOCOMLETE_INSTALL_WARNING}`));
+
+  if (isPluginInstalled(this.config, options.plugin.name)) {
+    logger.info(`Plugin ${options.plugin.name} is already installed.`);
+    return;
+  }
 
   if (!isTwilioPlugin(options.plugin.name)) {
     logger.warn('WARNING!!! You are attempting to install a plugin from an untrusted source.');


### PR DESCRIPTION
Related to #473

Implements a feature to skip plugin installation in Twilio CLI if the plugin is already installed, addressing a user request for improved build efficiency in CI environments.
- Adds a check in `src/hooks/plugin-install.js` to determine if a plugin is already installed using the `isPluginInstalled` function.
- Skips the installation process and logs an informative message to the user if the plugin is detected as already installed, enhancing user experience and saving time during automated builds.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/twilio/twilio-cli/issues/473?shareId=d6a05735-d763-4d05-9d2b-1617e22d5dbe).