### PR TITLE
chore: dynamically find correct signtool for windows

### DIFF
--- a/.github/workflows/windows-executable-release.yml
+++ b/.github/workflows/windows-executable-release.yml
@@ -90,7 +90,7 @@ jobs:
           smctl windows certsync
         shell: cmd
 
-      # NEW: find signtool.exe dynamically
+      # find signtool.exe dynamically
       - name: Find signtool.exe
         id: find_signtool
         shell: pwsh


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

# Fixes #

Recently the default signtool path has changed in github runner for `windows-latest`. Thus this change removes the hardcoded path and finds the correct signtool path at runtime for the windows runner.
 
Successful run logs: https://github.com/twilio/twilio-cli/actions/runs/19756865114/job/56610092313

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [ ] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-cli/blob/main/CONTRIBUTING.md) and my PR follows them
- [ ] I have titled the PR appropriately
- [ ] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
