### PR TITLE
fix: Map 'stable' update channel to 'latest' to resolve HTTP 403

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "twilio-cli",
-  "version": "6.2.2",
+  "version": "6.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "twilio-cli",
-      "version": "6.2.2",
+      "version": "6.2.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -18,7 +18,7 @@
         "@oclif/plugin-version": "^1.1.1",
         "@oclif/plugin-warn-if-update-available": "^3.0.18",
         "@sendgrid/mail": "^8.1.4",
-        "@twilio/cli-core": "8.2.5",
+        "@twilio/cli-core": "8.3.1",
         "chalk": "^4.1.2",
         "file-type": "^16.5.4",
         "hyperlinker": "1.0.0",
@@ -5870,9 +5870,9 @@
       "license": "MIT"
     },
     "node_modules/@twilio/cli-core": {
-      "version": "8.2.5",
-      "resolved": "https://registry.npmjs.org/@twilio/cli-core/-/cli-core-8.2.5.tgz",
-      "integrity": "sha512-jt2yyRHbwEC01BdtpJncQ//Qe2iBYe+sKFvq2LB+ywyhEhOVXLiQhssJAtkFWq6Tfrod0+R3znUeByJ1g0D2Kg==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/@twilio/cli-core/-/cli-core-8.3.1.tgz",
+      "integrity": "sha512-Lydw2ZlpMDk7/zsmUwoxQIW0yK8MWlPt/2DRn3HdYkjj8yoFpuUUBTdOWmRiQe7gwvSS6Q2hylHWeuiJs/8CDg==",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -145,7 +145,21 @@
     "update": {
       "s3": {
         "xz": true,
-        "bucket": "twilio-cli-prod"
+        "bucket": "twilio-cli-prod",
+        "templates": {
+          "target": {
+            "baseDir": "<%- bin %>",
+            "unversioned": "channels/<%- channel === 'stable' ? 'latest' : channel %>/<%- bin %>-<%- platform %>-<%- arch %><%- ext %>",
+            "versioned": "channels/<%- channel === 'stable' ? 'latest' : channel %>/<%- bin %>-v<%- version %>/<%- bin %>-v<%- version %>-<%- platform %>-<%- arch %><%- ext %>",
+            "manifest": "channels/<%- channel === 'stable' ? 'latest' : channel %>/<%- platform %>-<%- arch %>"
+          },
+          "vanilla": {
+            "unversioned": "channels/<%- channel === 'stable' ? 'latest' : channel %>/<%- bin %><%- ext %>",
+            "versioned": "channels/<%- channel === 'stable' ? 'latest' : channel %>/<%- bin %>-v<%- version %>/<%- bin %>-v<%- version %><%- ext %>",
+            "baseDir": "<%- bin %>",
+            "manifest": "channels/<%- channel === 'stable' ? 'latest' : channel %>/version"
+          }
+        }
       }
     },
     "helpClass": "./src/services/twilio-help/custom-help"


### PR DESCRIPTION
## Summary

- Fixes HTTP 403 error when running `twilio update` without arguments
- Maps the "stable" channel to "latest" in S3 bucket paths by overriding the S3 templates in package.json
- No infrastructure or workflow changes required

## Problem

When running `twilio update`, users encounter:
```
Error: HTTP 403: Invalid channel stable
```

**Root Cause:** The oclif framework defaults to the "stable" channel, which expects manifest files at the S3 bucket root (e.g., `https://twilio-cli-prod.s3.amazonaws.com/twilio-darwin-arm64-buildmanifest`). However, these files are either missing or inaccessible at that location.

## Solution

This PR adds S3 template overrides in `package.json` to redirect "stable" channel requests to "latest" channel paths (under `channels/latest/` in the S3 bucket). This approach:

- Requires only a code change in package.json
- No S3 infrastructure changes needed
- No workflow modifications required
- "latest" is semantically appropriate for production updates
- Minimal risk - if "latest" doesn't exist, error messages will be clear

## Changes

- Updated `package.json` oclif.update.s3.templates configuration
- Overridden S3 path templates to map "stable" → "latest"
- Other channels (rc, draft) remain unchanged

## Test Plan

- [x] All existing tests pass (208 passing)
- [ ] Verify `twilio update` works without 403 error after release
- [ ] Verify `twilio update --available` shows available versions
- [ ] Test different channels: `twilio update rc`, `twilio update draft`

🤖 Generated with [Claude Code](https://claude.com/claude-code)