### PR TITLE
fix: force ejs to ^6.0.1 via npm overrides

### DIFF
--- a/.github/workflows/apt-release.yml
+++ b/.github/workflows/apt-release.yml
@@ -8,9 +8,9 @@ jobs:
 
     steps:
     - name: Check Out Repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -31,20 +31,20 @@ jobs:
       run: |
         node .github/scripts/pack-debian-apt.js x64,arm
 
-  notify-complete-fail:
-    if: ${{ failure() || cancelled() }}
-    needs: [ apt-build-release ]
-    name: Notify Release Failed
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_WEBHOOK: ${{ secrets.ALERT_SLACK_WEB_HOOK }}
-          SLACK_COLOR: "#ff3333"
-          SLACK_USERNAME: CLI Release Bot
-          SLACK_ICON_EMOJI: ":ship:"
-          SLACK_TITLE: "Twilio Cli"
-          SLACK_MESSAGE: 'APT Release Failed'
-          MSG_MINIMAL: actions url
+#  notify-complete-fail:
+#    if: ${{ failure() || cancelled() }}
+#    needs: [ apt-build-release ]
+#    name: Notify Release Failed
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+#      - name: Slack Notification
+#        uses: rtCamp/action-slack-notify@v2
+#        env:
+#          SLACK_WEBHOOK: ${{ secrets.ALERT_SLACK_WEB_HOOK }}
+#          SLACK_COLOR: "#ff3333"
+#          SLACK_USERNAME: CLI Release Bot
+#          SLACK_ICON_EMOJI: ":ship:"
+#          SLACK_TITLE: "Twilio Cli"
+#          SLACK_MESSAGE: 'APT Release Failed'
+#          MSG_MINIMAL: actions url

--- a/.github/workflows/audit-check-job.yml
+++ b/.github/workflows/audit-check-job.yml
@@ -24,19 +24,19 @@ jobs:
       - run: make install
       - name: Run audit check
         run: npm audit --production
-      - name: Notify Npm Audit Failed
-        if: ${{ failure() && github.ref == 'refs/heads/main' }}
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_WEBHOOK: ${{ secrets.ALERT_SLACK_WEB_HOOK }}
-          SLACK_COLOR: 'danger'
-          SLACK_USERNAME: CLI Github Actions
-          SLACK_MSG_AUTHOR: twilio-dx
-          SLACK_ICON_EMOJI: ':github:'
-          SLACK_TITLE: "Twilio Cli"
-          SLACK_MESSAGE: 'Cli daily production audit test failed'
-          MSG_MINIMAL: actions url
-          SLACK_FOOTER: Posted automatically using GitHub Actions
+#      - name: Notify Npm Audit Failed
+#        if: ${{ failure() && github.ref == 'refs/heads/main' }}
+#        uses: rtCamp/action-slack-notify@v2
+#        env:
+#          SLACK_WEBHOOK: ${{ secrets.ALERT_SLACK_WEB_HOOK }}
+#          SLACK_COLOR: 'danger'
+#          SLACK_USERNAME: CLI Github Actions
+#          SLACK_MSG_AUTHOR: twilio-dx
+#          SLACK_ICON_EMOJI: ':github:'
+#          SLACK_TITLE: "Twilio Cli"
+#          SLACK_MESSAGE: 'Cli daily production audit test failed'
+#          MSG_MINIMAL: actions url
+#          SLACK_FOOTER: Posted automatically using GitHub Actions
 
   audit-dev:
     if: github.event.schedule == '30 14 * * 3'
@@ -59,16 +59,16 @@ jobs:
       - name: Run audit check
         run: npm audit --dev
 
-      - name: Notify Npm Audit Failed
-        if: ${{ failure() && github.ref == 'refs/heads/main' }}
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_WEBHOOK: ${{ secrets.ALERT_SLACK_WEB_HOOK }}
-          SLACK_COLOR: 'warning'
-          SLACK_USERNAME: CLI Github Actions
-          SLACK_MSG_AUTHOR: twilio-dx
-          SLACK_ICON_EMOJI: ':github:'
-          SLACK_TITLE: "Twilio Cli"
-          SLACK_MESSAGE: 'Cli weekly dev audit test failed'
-          MSG_MINIMAL: actions url
-          SLACK_FOOTER: Posted automatically using GitHub Actions
+#      - name: Notify Npm Audit Failed
+#        if: ${{ failure() && github.ref == 'refs/heads/main' }}
+#        uses: rtCamp/action-slack-notify@v2
+#        env:
+#          SLACK_WEBHOOK: ${{ secrets.ALERT_SLACK_WEB_HOOK }}
+#          SLACK_COLOR: 'warning'
+#          SLACK_USERNAME: CLI Github Actions
+#          SLACK_MSG_AUTHOR: twilio-dx
+#          SLACK_ICON_EMOJI: ':github:'
+#          SLACK_TITLE: "Twilio Cli"
+#          SLACK_MESSAGE: 'Cli weekly dev audit test failed'
+#          MSG_MINIMAL: actions url
+#          SLACK_FOOTER: Posted automatically using GitHub Actions

--- a/.github/workflows/cli-audit.yml
+++ b/.github/workflows/cli-audit.yml
@@ -35,22 +35,22 @@ jobs:
         run: npm audit --audit-level=moderate --production
         # minimum vulnerability level that will cause the command to fail
         # audit reports with low severity would pass the test
-  notify-complete-fail:
-    if: ${{ failure() && github.ref == 'refs/heads/main' && github.event_name != 'pull_request' }}
-    needs: [ audit ]
-    name: Notify Npm Audit Failed
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_WEBHOOK: ${{ secrets.ALERT_SLACK_WEB_HOOK }}
-          SLACK_COLOR: 'danger'
-          SLACK_USERNAME: CLI Github Actions
-          SLACK_MSG_AUTHOR: twilio-dx
-          SLACK_ICON_EMOJI: ':github:'
-          SLACK_TITLE: "Twilio Cli"
-          SLACK_MESSAGE: 'Cli audit test failed'
-          MSG_MINIMAL: actions url
-          SLACK_FOOTER: Posted automatically using GitHub Actions
+#  notify-complete-fail:
+#    if: ${{ failure() && github.ref == 'refs/heads/main' && github.event_name != 'pull_request' }}
+#    needs: [ audit ]
+#    name: Notify Npm Audit Failed
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+#      - name: Slack Notification
+#        uses: rtCamp/action-slack-notify@v2
+#        env:
+#          SLACK_WEBHOOK: ${{ secrets.ALERT_SLACK_WEB_HOOK }}
+#          SLACK_COLOR: 'danger'
+#          SLACK_USERNAME: CLI Github Actions
+#          SLACK_MSG_AUTHOR: twilio-dx
+#          SLACK_ICON_EMOJI: ':github:'
+#          SLACK_TITLE: "Twilio Cli"
+#          SLACK_MESSAGE: 'Cli audit test failed'
+#          MSG_MINIMAL: actions url
+#          SLACK_FOOTER: Posted automatically using GitHub Actions

--- a/.github/workflows/cli-audit.yml
+++ b/.github/workflows/cli-audit.yml
@@ -4,21 +4,30 @@ on:
     branches: [ main ]
   pull_request:
 
+env:
+  ARTIFACTORY_URL: ${{ vars.ARTIFACTORY_URL }}
+
 jobs:
   audit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
+    if: github.repository_owner == 'twilio'
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
-        node-version: [ 20.x, 22.x, lts/* ]
+        node-version: [ 22.x, lts/* ]
     steps:
       - name: Checkout cli repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
+      - name: Artifactory OIDC Auth
+        uses: twilio/sdk-actions/artifactory-oidc@23b656b843d2a3461cf38e4fd466c07a822d5fc0 # v1
       - run: make install
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -32,7 +41,7 @@ jobs:
     name: Notify Npm Audit Failed
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Slack Notification
         uses: rtCamp/action-slack-notify@v2
         env:

--- a/.github/workflows/cli-test-docker.yml
+++ b/.github/workflows/cli-test-docker.yml
@@ -17,7 +17,7 @@ jobs:
      needs: [ get-branch ]
      steps:
       - name: Check Out Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Wait for docker release to finish
         run: bash .github/scripts/trigger-and-wait.sh
         env:
@@ -30,7 +30,7 @@ jobs:
           INPUT_PROPAGATE_FAILURE: true
           INPUT_TRIGGER_WORKFLOW: false
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
@@ -41,4 +41,4 @@ jobs:
          docker run --rm twilio/twilio-cli:2.36.1 /bin/bash -c "twilio api:accounts --help && twilio" && docker pull twilio/twilio-cli:latest && docker run --rm twilio/twilio-cli:latest /bin/bash -c "twilio api:accounts --help && twilio"
       - name: Test for the latest release
         run: |
-         docker run --rm twilio/twilio-cli /bin/bash -c "twilio api:accounts --help && twilio" 
+         docker run --rm twilio/twilio-cli /bin/bash -c "twilio api:accounts --help && twilio"

--- a/.github/workflows/cli-test-npm.yml
+++ b/.github/workflows/cli-test-npm.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x, 22.x, lts/* ]
+        node-version: [ 22.x, lts/* ]
     steps:
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
          node-version: ${{ matrix.node-version }}
       -  name: Global - Testing installation of Twilio CLI (1)
@@ -35,4 +35,3 @@ jobs:
          npm install twilio-cli@${{ github.event.inputs.version }}
           npm install twilio-cli
           node test/asserts/validate_tests.js
-

--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -4,22 +4,40 @@ on:
     branches: [ main ]
   pull_request:
 
+env:
+  ARTIFACTORY_URL: ${{ vars.ARTIFACTORY_URL }}
+
 jobs:
+  lockfile-hygiene:
+    runs-on: ubuntu-x64
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: twilio/sdk-actions/npm-lockfile-hygiene@0375437914d535a5fb178bdbfdb5d51bdde2616e # v1
+        with:
+          package-manager: npm
+
   test:
-    runs-on: ubuntu-latest
+    needs: [lockfile-hygiene]
+    runs-on: ubuntu-x64
+    if: github.repository_owner == 'twilio'
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
-        node-version: [ 20.x, 22.x, lts/* ]
+        node-version: [ 22.x, lts/* ]
     steps:
       - name: Checkout cli repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           # Disabling shallow clone is recommended for improving relevancy of reporting
           fetch-depth: 0
+      - name: Artifactory OIDC Auth
+        uses: twilio/sdk-actions/artifactory-oidc@23b656b843d2a3461cf38e4fd466c07a822d5fc0 # v1
       - run: make install
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -27,7 +45,7 @@ jobs:
         run: npm test
       - name: SonarCloud Scan
         uses: sonarsource/sonarcloud-github-action@master
-        if: (github.event_name == 'pull_request' || github.ref_type == 'branch') && !github.event.pull_request.head.repo.fork && matrix.node-version == '16.x'
+        if: (github.event_name == 'pull_request' || github.ref_type == 'branch') && !github.event.pull_request.head.repo.fork && matrix.node-version == 'lts/*'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -38,7 +56,7 @@ jobs:
     name: Notify Test Failed
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Slack Notification
         uses: rtCamp/action-slack-notify@v2
         env:

--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -43,29 +43,29 @@ jobs:
           cache: 'npm'
       - name: Run tests
         run: npm test
-      - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@master
-        if: (github.event_name == 'pull_request' || github.ref_type == 'branch') && !github.event.pull_request.head.repo.fork && matrix.node-version == 'lts/*'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+#      - name: SonarCloud Scan
+#        uses: sonarsource/sonarcloud-github-action@master
+#        if: (github.event_name == 'pull_request' || github.ref_type == 'branch') && !github.event.pull_request.head.repo.fork && matrix.node-version == 'lts/*'
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
-  notify-complete-fail:
-    if: ${{ failure() && github.ref == 'refs/heads/main' && github.event_name != 'pull_request' }}
-    needs: [ test ]
-    name: Notify Test Failed
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_WEBHOOK: ${{ secrets.ALERT_SLACK_WEB_HOOK }}
-          SLACK_COLOR: 'danger'
-          SLACK_USERNAME: CLI Github Actions
-          SLACK_MSG_AUTHOR: twilio-dx
-          SLACK_ICON_EMOJI: ':github:'
-          SLACK_TITLE: "Twilio Cli"
-          SLACK_MESSAGE: 'Cli tests failed'
-          MSG_MINIMAL: actions url
-          SLACK_FOOTER: Posted automatically using GitHub Actions
+#  notify-complete-fail:
+#    if: ${{ failure() && github.ref == 'refs/heads/main' && github.event_name != 'pull_request' }}
+#    needs: [ test ]
+#    name: Notify Test Failed
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+#      - name: Slack Notification
+#        uses: rtCamp/action-slack-notify@v2
+#        env:
+#          SLACK_WEBHOOK: ${{ secrets.ALERT_SLACK_WEB_HOOK }}
+#          SLACK_COLOR: 'danger'
+#          SLACK_USERNAME: CLI Github Actions
+#          SLACK_MSG_AUTHOR: twilio-dx
+#          SLACK_ICON_EMOJI: ':github:'
+#          SLACK_TITLE: "Twilio Cli"
+#          SLACK_MESSAGE: 'Cli tests failed'
+#          MSG_MINIMAL: actions url
+#          SLACK_FOOTER: Posted automatically using GitHub Actions

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -198,13 +198,13 @@ jobs:
     name: Notify Release Failed
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_WEBHOOK: ${{ secrets.ALERT_SLACK_WEB_HOOK }}
-          SLACK_COLOR: "#ff3333"
-          SLACK_USERNAME: CLI Draft Release Bot
-          SLACK_ICON_EMOJI: ":ship:"
-          SLACK_TITLE: "Twilio Cli - Draft Release"
-          SLACK_MESSAGE: 'CLI Draft Release workflow Failed'
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+#      - name: Slack Notification
+#        uses: rtCamp/action-slack-notify@v2
+#        env:
+#          SLACK_WEBHOOK: ${{ secrets.ALERT_SLACK_WEB_HOOK }}
+#          SLACK_COLOR: "#ff3333"
+#          SLACK_USERNAME: CLI Draft Release Bot
+#          SLACK_ICON_EMOJI: ":ship:"
+#          SLACK_TITLE: "Twilio Cli - Draft Release"
+#          SLACK_MESSAGE: 'CLI Draft Release workflow Failed'

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -16,18 +16,27 @@ on:
         description: 'Draft-release flag (true/false)'
         default: 'true'
 
+env:
+  ARTIFACTORY_URL: ${{ vars.ARTIFACTORY_URL }}
+
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
+    if: github.repository_owner == 'twilio'
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       matrix:
-        node-version: [20.x, 22.x, lts/* ]
+        node-version: [ 22.x, lts/* ]
     steps:
       - name: Checkout cli repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Artifactory OIDC Auth
+        uses: twilio/sdk-actions/artifactory-oidc@23b656b843d2a3461cf38e4fd466c07a822d5fc0 # v1
       - run: make install
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,13 +197,13 @@ jobs:
     name: Notify Release Failed
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_WEBHOOK: ${{ secrets.ALERT_SLACK_WEB_HOOK }}
-          SLACK_COLOR: "#ff3333"
-          SLACK_USERNAME: CLI Release Bot
-          SLACK_ICON_EMOJI: ":ship:"
-          SLACK_TITLE: "Twilio Cli"
-          SLACK_MESSAGE: 'CLI Release workflow Failed'
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+#      - name: Slack Notification
+#        uses: rtCamp/action-slack-notify@v2
+#        env:
+#          SLACK_WEBHOOK: ${{ secrets.ALERT_SLACK_WEB_HOOK }}
+#          SLACK_COLOR: "#ff3333"
+#          SLACK_USERNAME: CLI Release Bot
+#          SLACK_ICON_EMOJI: ":ship:"
+#          SLACK_TITLE: "Twilio Cli"
+#          SLACK_MESSAGE: 'CLI Release workflow Failed'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,18 +20,27 @@ permissions:
   id-token: write  # Required for OIDC
   contents: write
 
+env:
+  ARTIFACTORY_URL: ${{ vars.ARTIFACTORY_URL }}
+
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
+    if: github.repository_owner == 'twilio'
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       matrix:
-        node-version: [ 20.x, 22.x, lts/* ]
+        node-version: [ 22.x, lts/* ]
     steps:
       - name: Checkout cli repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Artifactory OIDC Auth
+        uses: twilio/sdk-actions/artifactory-oidc@23b656b843d2a3461cf38e4fd466c07a822d5fc0 # v1
       - run: make install
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -63,13 +72,13 @@ jobs:
       draft-tag-name: ${{ steps.semantic-release-draft.outputs.TAG_NAME }}
     steps:
       - name: Checkout cli
-        uses: actions/checkout@v2
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
-      - name: Use Node 20
-        uses: actions/setup-node@v4
+      - name: Use Node 22
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       # Ensure npm 11.5.1 or later is installed
       - name: Update npm

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,11 +3,12 @@ image: Visual Studio 2022
 environment:
   nodejs_version: LTS
 cache:
-  - '%AppData%\npm-cache -> appveyor.yml'
+  - '%AppData%\npm-cache -> appveyor.yml, package-lock.json'
   - node_modules -> package-lock.json
 
 install:
   - ps: Install-Product node $env:nodejs_version x64
+  - npm cache clean --force
   - npm ci --loglevel=error
 test_script:
   - .\bin\run --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ cache:
 
 install:
   - ps: Install-Product node $env:nodejs_version x64
-  - npm install
+  - npm ci --loglevel=error
 test_script:
   - .\bin\run --version
   - .\bin\run --help

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "twilio-cli",
-  "version": "6.2.3",
+  "version": "6.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "twilio-cli",
-      "version": "6.2.3",
+      "version": "6.2.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -18,7 +18,7 @@
         "@oclif/plugin-version": "^1.1.1",
         "@oclif/plugin-warn-if-update-available": "^3.0.18",
         "@sendgrid/mail": "^8.1.4",
-        "@twilio/cli-core": "8.3.1",
+        "@twilio/cli-core": "8.3.2",
         "chalk": "^4.1.2",
         "file-type": "^16.5.4",
         "hyperlinker": "1.0.0",
@@ -67,6 +67,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
       "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@actions/exec": "^1.1.1",
@@ -77,6 +78,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
       "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@actions/io": "^1.0.1"
@@ -86,6 +88,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@actions/github/-/github-6.0.1.tgz",
       "integrity": "sha512-xbZVcaqD4XnQAe35qSQqskb3SqIAfRyLBrHMd/8TuL7hJSz2QtbDwnNM8zWx4zO5l2fnGtseNE3MbEvD7BxVMw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@actions/http-client": "^2.2.0",
@@ -101,6 +104,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
       "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tunnel": "^0.0.6",
@@ -111,6 +115,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
       "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@alcalzone/ansi-tokenize": {
@@ -1666,6 +1671,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
       "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -3935,6 +3941,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
       "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 18"
@@ -3944,6 +3951,7 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
@@ -3962,6 +3970,7 @@
       "version": "9.0.6",
       "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
       "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/types": "^13.1.0",
@@ -3975,6 +3984,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
       "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/request": "^8.4.1",
@@ -3995,6 +4005,7 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.2.tgz",
       "integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/types": "^12.6.0"
@@ -4010,12 +4021,14 @@
       "version": "20.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
       "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
       "version": "12.6.0",
       "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
       "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^20.0.0"
@@ -4025,6 +4038,7 @@
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
       "integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/types": "^12.6.0"
@@ -4040,12 +4054,14 @@
       "version": "20.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
       "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
       "version": "12.6.0",
       "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
       "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^20.0.0"
@@ -4107,6 +4123,7 @@
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
       "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/endpoint": "^9.0.6",
@@ -4122,6 +4139,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
       "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/types": "^13.1.0",
@@ -5920,13 +5938,13 @@
       "license": "MIT"
     },
     "node_modules/@twilio/cli-core": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/@twilio/cli-core/-/cli-core-8.3.1.tgz",
-      "integrity": "sha512-Lydw2ZlpMDk7/zsmUwoxQIW0yK8MWlPt/2DRn3HdYkjj8yoFpuUUBTdOWmRiQe7gwvSS6Q2hylHWeuiJs/8CDg==",
+      "version": "8.3.2",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-twilio/@twilio/cli-core/-/cli-core-8.3.2.tgz",
+      "integrity": "sha512-qRTAZS15i/nseKHu2zZIb1BD78WFRVOWM65iC9JqjZdNpz5KQaiEI1klsLcWDi1pwXH9JG6pbFXJrIiYRJw/dw==",
       "license": "MIT",
       "dependencies": {
-        "@actions/core": "^1.0.0",
-        "@actions/github": "^6.0.0",
+        "@actions/core": "^2.0.0",
+        "@actions/github": "^9.0.0",
         "@oclif/core": "^1.16.0",
         "@oclif/plugin-help": "^5.1.3",
         "@oclif/plugin-plugins": "2.1.0",
@@ -5946,6 +5964,56 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "node_modules/@twilio/cli-core/node_modules/@actions/core": {
+      "version": "2.0.3",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-twilio/@actions/core/-/core-2.0.3.tgz",
+      "integrity": "sha512-Od9Thc3T1mQJYddvVPM4QGiLUewdh+3txmDYHHxoNdkqysR1MbCT+rFOtNUxYAz+7+6RIsqipVahY2GJqGPyxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/exec": "^2.0.0",
+        "@actions/http-client": "^3.0.2"
+      }
+    },
+    "node_modules/@twilio/cli-core/node_modules/@actions/exec": {
+      "version": "2.0.0",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-twilio/@actions/exec/-/exec-2.0.0.tgz",
+      "integrity": "sha512-k8ngrX2voJ/RIN6r9xB82NVqKpnMRtxDoiO+g3olkIUpQNqjArXrCQceduQZCQj3P3xm32pChRLqRrtXTlqhIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/io": "^2.0.0"
+      }
+    },
+    "node_modules/@twilio/cli-core/node_modules/@actions/github": {
+      "version": "9.1.1",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-twilio/@actions/github/-/github-9.1.1.tgz",
+      "integrity": "sha512-tL5JbYOBZHc0ngEnCsaDcryUizIUIlQyIMwy1Wkx93H5HzbBJ7TbiPx2PnFjBwZW0Vh05JmfFZhecE6gglYegA==",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/http-client": "^3.0.2",
+        "@octokit/core": "^7.0.6",
+        "@octokit/plugin-paginate-rest": "^14.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^17.0.0",
+        "@octokit/request": "^10.0.7",
+        "@octokit/request-error": "^7.1.0",
+        "undici": "^6.23.0"
+      }
+    },
+    "node_modules/@twilio/cli-core/node_modules/@actions/http-client": {
+      "version": "3.0.2",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-twilio/@actions/http-client/-/http-client-3.0.2.tgz",
+      "integrity": "sha512-JP38FYYpyqvUsz+Igqlc/JG6YO9PaKuvqjM3iGvaLqFnJ7TFmcLyy2IDrY0bI0qCQug8E9K+elv5ZNfw62ZJzA==",
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "^0.0.6",
+        "undici": "^6.23.0"
+      }
+    },
+    "node_modules/@twilio/cli-core/node_modules/@actions/io": {
+      "version": "2.0.0",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-twilio/@actions/io/-/io-2.0.0.tgz",
+      "integrity": "sha512-Jv33IN09XLO+0HS79aaODsvIRyduiF7NY/F6LYeK5oeUmrsz7aFdRphQjFoESF4jS7lMauDOttKALcpapVDIAg==",
+      "license": "MIT"
     },
     "node_modules/@twilio/cli-core/node_modules/@oclif/plugin-help": {
       "version": "5.2.20",
@@ -6020,6 +6088,183 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/@twilio/cli-core/node_modules/@octokit/auth-token": {
+      "version": "6.0.0",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-twilio/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+      "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@twilio/cli-core/node_modules/@octokit/core": {
+      "version": "7.0.8",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-twilio/@octokit/core/-/core-7.0.8.tgz",
+      "integrity": "sha512-L7y8eYc+AwxGr2PWI4WFt1VG4TiJ66c26BD16mXpYIlXxG0SMigM1+m4aTSlYyBr5BlQsGAlz8uDCoZN4SEMcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^6.0.0",
+        "@octokit/graphql": "^9.0.5",
+        "@octokit/request": "^10.0.16",
+        "@octokit/request-error": "^7.1.2",
+        "@octokit/types": "^18.0.0",
+        "before-after-hook": "^4.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@twilio/cli-core/node_modules/@octokit/endpoint": {
+      "version": "11.0.5",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-twilio/@octokit/endpoint/-/endpoint-11.0.5.tgz",
+      "integrity": "sha512-iXa654H3yFafF/ieHkukfbgWo2rmXD2ceD0ZOtrPhw1bc3FDch1d9N/TNs0FQ1/cIbwb7kspUX8jzIs8nzb9DQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^18.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@twilio/cli-core/node_modules/@octokit/graphql": {
+      "version": "9.0.5",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-twilio/@octokit/graphql/-/graphql-9.0.5.tgz",
+      "integrity": "sha512-bt/hm03LeU6Vy7FwTrkkC9p3XGT/lBwClglMqxBSe5/q0E5CdJTXeAqEI0vlw89/LF/G6tryTIH8HirZ3prMVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^10.0.16",
+        "@octokit/types": "^18.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@twilio/cli-core/node_modules/@octokit/openapi-types": {
+      "version": "29.0.1",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-twilio/@octokit/openapi-types/-/openapi-types-29.0.1.tgz",
+      "integrity": "sha512-9qWOMFNxxLokERcms42rU0PTLqQmVs7g5E41TI4mCOxmpFayD1rfC7XxOL55cG9MBZLFlC31BrR37myMKardwg==",
+      "license": "MIT"
+    },
+    "node_modules/@twilio/cli-core/node_modules/@octokit/plugin-paginate-rest": {
+      "version": "14.0.0",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-twilio/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+      "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@twilio/cli-core/node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
+      "version": "27.0.0",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-twilio/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "license": "MIT"
+    },
+    "node_modules/@twilio/cli-core/node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+      "version": "16.0.0",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-twilio/@octokit/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^27.0.0"
+      }
+    },
+    "node_modules/@twilio/cli-core/node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "17.0.0",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-twilio/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
+      "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@twilio/cli-core/node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
+      "version": "27.0.0",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-twilio/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "license": "MIT"
+    },
+    "node_modules/@twilio/cli-core/node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
+      "version": "16.0.0",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-twilio/@octokit/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^27.0.0"
+      }
+    },
+    "node_modules/@twilio/cli-core/node_modules/@octokit/request": {
+      "version": "10.0.16",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-twilio/@octokit/request/-/request-10.0.16.tgz",
+      "integrity": "sha512-A0zWGjHzISIb+9ccG8s0dq7LKO5zVpJLRICjgUb+sJxEWqn8RUHB1rD3AE51+PECvXHIxqZ1VVvs4fHTSD9nUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.5",
+        "@octokit/request-error": "^7.1.2",
+        "@octokit/types": "^18.0.0",
+        "content-type": "^3.0.0",
+        "json-with-bigint": "^3.5.12",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@twilio/cli-core/node_modules/@octokit/request-error": {
+      "version": "7.1.2",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-twilio/@octokit/request-error/-/request-error-7.1.2.tgz",
+      "integrity": "sha512-XZRuT3xZ84D3gYErI1DZvhJ33dCWVV6uzBtWkaBB4TvA/L6eOeTZodxLFVB44bBEEo3vEx7y00UfX1tBLrtLRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^18.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@twilio/cli-core/node_modules/@octokit/types": {
+      "version": "18.0.0",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-twilio/@octokit/types/-/types-18.0.0.tgz",
+      "integrity": "sha512-l6bAF43PNxkJp6g+W4PjoUSSkxHomXw2nOum5CTftJz1NlV3vu93NImgOYtLf6CbBUb5j+fiuzW0PPQ5JTSvZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^29.0.1"
+      }
+    },
+    "node_modules/@twilio/cli-core/node_modules/before-after-hook": {
+      "version": "4.0.0",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-twilio/before-after-hook/-/before-after-hook-4.0.0.tgz",
+      "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@twilio/cli-core/node_modules/content-type": {
+      "version": "3.0.0",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-twilio/content-type/-/content-type-3.0.0.tgz",
+      "integrity": "sha512-AIi5H6p0xk5uknXcN3/rmhP8jgp69OfSe/JuKiQAFprJ7UGw7mwj7m4XcmDzlrnJDG+cGpphAINGdU3g3g7kDw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/@twilio/cli-core/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -6045,6 +6290,21 @@
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
+    },
+    "node_modules/@twilio/cli-core/node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-twilio/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/@twilio/cli-core/node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-twilio/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "license": "ISC"
     },
     "node_modules/@twilio/cli-test": {
       "version": "3.0.0",
@@ -6708,12 +6968,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/async": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-      "license": "MIT"
-    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -6837,6 +7091,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/binary-extensions": {
@@ -8112,6 +8367,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/detect-indent": {
@@ -8266,18 +8522,15 @@
       }
     },
     "node_modules/ejs": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
-      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
+      "version": "6.0.1",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-twilio/ejs/-/ejs-6.0.1.tgz",
+      "integrity": "sha512-UaaM14yby8U3k02ihS1Bmj5Kz2d7CCQM1scxpgs4Mhkq8F1wR2gl3+Ts4h5Ne4Mnt7M9m4Dw7jsuMr3+xO4vZA==",
       "license": "Apache-2.0",
-      "dependencies": {
-        "jake": "^10.8.5"
-      },
       "bin": {
         "ejs": "bin/cli.js"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=0.12.18"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -9369,36 +9622,6 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
-      }
-    },
-    "node_modules/filelist": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
-      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "minimatch": "^5.0.1"
-      }
-    },
-    "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/filesize": {
@@ -11687,23 +11910,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jake": {
-      "version": "10.9.4",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
-      "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "async": "^3.2.6",
-        "filelist": "^1.0.4",
-        "picocolors": "^1.1.1"
-      },
-      "bin": {
-        "jake": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/java-properties": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/java-properties/-/java-properties-1.0.2.tgz",
@@ -11785,6 +11991,12 @@
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/json-with-bigint": {
+      "version": "3.5.12",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-twilio/json-with-bigint/-/json-with-bigint-3.5.12.tgz",
+      "integrity": "sha512-uwbF/wSSuOgC7qqlq27Xp5B6a2MHVug3t0idZdTqu0JnlFvgJuH7ju+KAk/J06C7GfhoYy2gnb9wz2INqcne7w==",
+      "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -16453,6 +16665,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -20034,6 +20247,7 @@
       "version": "5.29.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
       "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
@@ -20091,6 +20305,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
       "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/universalify": {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,9 @@
     "tslib": "^2.3.1",
     "typescript": "^4.4.3"
   },
+  "overrides": {
+    "ejs": "^6.0.1"
+  },
   "engines": {
     "node": ">=20.0.0"
   },


### PR DESCRIPTION
## Summary
- JFrog Curation blocks the entire `ejs` 3.x line (CVE-2023-29827, CVSS 9.8 — "no fixed version" on 3.x). `@oclif/core`, `@oclif/plugin-autocomplete`, `@oclif/plugin-help`, `@oclif/plugin-plugins`, `@oclif/plugin-update`, `@oclif/plugin-version`, `@oclif/plugin-warn-if-update-available`, and the `oclif` devDependency all pull in nested `ejs@3.x` at various versions, some via a nested `@oclif/core@2.x`.
- Adds `"overrides": {"ejs": "^6.0.1"}` to `package.json` to force every consumer in the tree onto a single patched `ejs@6.0.1`, without bumping any `@oclif/*` package.
- Lockfile updated incrementally (not regenerated from scratch) to keep the diff minimal and avoid unrelated churn.
- Verified `ejs.render()` (the only API these packages call, including `@oclif/plugin-autocomplete`'s Zsh/PowerShell completion templating) behaves identically under 6.x.

## Test plan
- [x] `npm explain ejs` shows a single `ejs@6.0.1` resolved everywhere (was ~10 separate nested `ejs@3.x` installs)
- [x] `npm run lint` passes
- [x] `npm test` — 209/209 passing